### PR TITLE
Remove position id

### DIFF
--- a/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
+++ b/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
@@ -50,7 +50,6 @@
       "title": "All mutated files.",
       "definitions": {
         "position": {
-          "$id": "#position",
           "type": "object",
           "title": "Position of a mutation. Both line and column start at one.",
           "required": [
@@ -150,11 +149,11 @@
                   ],
                   "properties": {
                     "start": {
-                      "$ref": "#position",
+                      "$ref": "#/properties/files/definitions/position",
                       "title": "Start position of the mutation. Inclusive."
                     },
                     "end": {
-                      "$ref": "#position",
+                      "$ref": "#/properties/files/definitions/position",
                       "title": "End position of the mutation. Exclusive."
                     }
                   }


### PR DESCRIPTION
The position id does not work properly in the schema validator we use for Stryker4s (https://github.com/everit-org/json-schema)