### PR TITLE
build: add cache to speed up travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
 - node
+cache:
+  npm: true
+  directories:
+  - $HOME/.m2/repository # Maven cache
 addons:
   chrome: stable
 script: npm run all


### PR DESCRIPTION
Adds a `node_modules` and maven repo cache