### PR TITLE
Feat/emoj and no coverage color

### DIFF
--- a/packages/mutation-testing-elements/src/components/mutation-test-report-file-legend.ts
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-file-legend.ts
@@ -1,6 +1,7 @@
 import { customElement, LitElement, property, PropertyValues, html, css } from 'lit-element';
 import { MutantResult, MutantStatus } from 'mutation-testing-report-schema';
 import { bootstrap } from '../style';
+import { getContextClassForStatus, getEmojiForStatus } from '../lib/htmlHelpers';
 
 export interface MutantFilter {
   status: MutantStatus;
@@ -65,6 +66,7 @@ export class MutationTestReportFileLegendComponent extends LitElement {
   }
 
   public static styles = [
+    bootstrap,
     css`
       .legend{
         position: sticky;
@@ -76,17 +78,23 @@ export class MutationTestReportFileLegendComponent extends LitElement {
         padding-bottom: 0.5rem;
         z-index: 10;
       }
-  `, bootstrap];
+      .badge {
+        font-size: 1em;
+        cursor: pointer;
+      }
+      .
+  `];
 
   public render() {
     return html`
       <div class='row legend'>
         <form class='col-md-12' novalidate='novalidate'>
           ${this.filters.map(filter => html`
-          <div class="form-check form-check-inline">
+          <div data-status="${filter.status}" class="form-check form-check-inline">
             <label class="form-check-label">
               <input class="form-check-input" type="checkbox" ?checked="${filter.enabled}" value="${filter.status}" @input="${() => this.checkboxClicked(filter)}">
-              ${filter.status} (${filter.numberOfMutants})
+              <span class="badge badge-${getContextClassForStatus(filter.status)}">${getEmojiForStatus(filter.status)}
+                ${filter.status} (${filter.numberOfMutants})</span>
             </label>
           </div>
           `)}

--- a/packages/mutation-testing-elements/src/components/mutation-test-report-file/mutation-test-report-file.scss
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-file/mutation-test-report-file.scss
@@ -1,3 +1,5 @@
+@import "../../style/bootstrap-reboot.scss"; // import the variables
+
 .bg-danger-light {
     background-color: #f2dede;
 }
@@ -6,11 +8,17 @@
     background-color: #dff0d8;
 }
 
+
 .bg-warning-light {
     background-color: #fcf8e3;
 }
 
-code, code.hljs {
+.bg-caution-light {
+    background-color: adjust-color($color: theme-color('caution'), $lightness: 40%);
+}
+
+code,
+code.hljs {
     overflow: visible;
     height: 100%;
 }

--- a/packages/mutation-testing-elements/src/lib/htmlHelpers.ts
+++ b/packages/mutation-testing-elements/src/lib/htmlHelpers.ts
@@ -5,6 +5,7 @@ export function getContextClassForStatus(status: MutantStatus) {
     case MutantStatus.Killed:
       return 'success';
     case MutantStatus.NoCoverage:
+      return 'caution'; // custom class
     case MutantStatus.Survived:
       return 'danger';
     case MutantStatus.Timeout:
@@ -18,15 +19,16 @@ export function getContextClassForStatus(status: MutantStatus) {
 export function getEmojiForStatus(status: MutantStatus) {
   switch (status) {
     case MutantStatus.Killed:
-      return '✔';
+      return '✅';
     case MutantStatus.NoCoverage:
+      return '🙈';
     case MutantStatus.Survived:
-      return '❌';
+      return '👽';
     case MutantStatus.Timeout:
       return '⌛';
     case MutantStatus.RuntimeError:
     case MutantStatus.CompileError:
-      return '⚠';
+      return '💥';
   }
 }
 

--- a/packages/mutation-testing-elements/src/style/bootstrap-reboot.scss
+++ b/packages/mutation-testing-elements/src/style/bootstrap-reboot.scss
@@ -1,0 +1,8 @@
+@import "~bootstrap/scss/bootstrap-reboot.scss";
+$theme-colors: map-merge(
+  (
+    "caution":    $orange, // Add custom warning color
+  ),
+  $theme-colors
+);
+

--- a/packages/mutation-testing-elements/src/style/bootstrap.scss
+++ b/packages/mutation-testing-elements/src/style/bootstrap.scss
@@ -1,4 +1,5 @@
-@import "~bootstrap/scss/bootstrap-reboot.scss";
+@import "bootstrap-reboot.scss";
+
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/type";
 
@@ -18,3 +19,5 @@
 @import "~bootstrap/scss/utilities/_text.scss";
 @import "~bootstrap/scss/utilities/_background.scss";
 // @import "~bootstrap/scss/bootstrap.scss";
+
+

--- a/packages/mutation-testing-elements/test/helpers/helperFunctions.ts
+++ b/packages/mutation-testing-elements/test/helpers/helperFunctions.ts
@@ -1,4 +1,4 @@
-import { MutantStatus } from "mutation-testing-report-schema";
+import { MutantStatus } from 'mutation-testing-report-schema';
 
 export function normalizeWhitespace(pseudoHtml: string) {
   return pseudoHtml.replace(/\s+/g, ' ').trim();

--- a/packages/mutation-testing-elements/test/helpers/helperFunctions.ts
+++ b/packages/mutation-testing-elements/test/helpers/helperFunctions.ts
@@ -1,0 +1,14 @@
+import { MutantStatus } from "mutation-testing-report-schema";
+
+export function normalizeWhitespace(pseudoHtml: string) {
+  return pseudoHtml.replace(/\s+/g, ' ').trim();
+}
+
+export const expectedMutantColors = Object.freeze({
+  [MutantStatus.Killed]: 'rgb(40, 167, 69)',
+  [MutantStatus.Survived]: 'rgb(220, 53, 69)',
+  [MutantStatus.NoCoverage]: 'rgb(253, 126, 20)',
+  [MutantStatus.Timeout]: 'rgb(255, 193, 7)',
+  [MutantStatus.CompileError]: 'rgb(108, 117, 125)',
+  [MutantStatus.RuntimeError]: 'rgb(108, 117, 125)'
+});

--- a/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file-legend.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file-legend.spec.ts
@@ -2,6 +2,7 @@ import { MutationTestReportFileLegendComponent, MutantFilter } from '../../../sr
 import { CustomElementFixture } from '../helpers/CustomElementFixture';
 import { MutantStatus } from 'mutation-testing-report-schema';
 import { expect } from 'chai';
+import { normalizeWhitespace, expectedMutantColors } from '../../helpers/helperFunctions';
 
 describe(MutationTestReportFileLegendComponent.name, () => {
 
@@ -34,14 +35,38 @@ describe(MutationTestReportFileLegendComponent.name, () => {
     await sut.updateComplete;
     const actualCheckboxes = sut.$$('.form-check.form-check-inline');
     expect(actualCheckboxes).lengthOf(6);
-    const checkboxTexts = actualCheckboxes.map(checkbox => (checkbox.textContent as string).trim());
-    expect(checkboxTexts).deep.eq(['Killed (1)',
-      'Survived (1)',
-      'NoCoverage (1)',
-      'Timeout (1)',
-      'CompileError (1)',
-      'RuntimeError (1)'
+    const checkboxTexts = actualCheckboxes.map(checkbox => normalizeWhitespace((checkbox.textContent as string)));
+    expect(checkboxTexts).deep.eq([
+      '✅ Killed (1)',
+      '👽 Survived (1)',
+      '🙈 NoCoverage (1)',
+      '⌛ Timeout (1)',
+      '💥 CompileError (1)',
+      '💥 RuntimeError (1)'
     ]);
+  });
+
+  it('should show the correct colors for the states', async () => {
+    // Arrange
+    sut.element.mutants = [
+      { status: MutantStatus.CompileError },
+      { status: MutantStatus.Killed },
+      { status: MutantStatus.NoCoverage },
+      { status: MutantStatus.RuntimeError },
+      { status: MutantStatus.Survived },
+      { status: MutantStatus.Timeout }
+    ];
+
+    // Act
+    await sut.updateComplete;
+
+    // Assert
+    function assertColor(status: string, expectedColor: string) {
+      expect(getComputedStyle(sut.$(`[data-status=${status}] .badge`)).backgroundColor).eq(expectedColor);
+    }
+    Object.keys(expectedMutantColors).forEach(status => {
+      assertColor(status, expectedMutantColors[status as  MutantStatus]);
+    });
   });
 
   it('should dispatch the "filters-changed" event for the initial state', async () => {

--- a/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file-legend.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file-legend.spec.ts
@@ -19,57 +19,52 @@ describe(MutationTestReportFileLegendComponent.name, () => {
 
   describe('filter buttons', () => {
 
-  it('should display no checkboxes without mutants', () => {
-    expect(sut.$$('input[checkbox]')).lengthOf(0);
-  });
-
-  it('should display checkboxes for all states', async () => {
-    sut.element.mutants = [
-      { status: MutantStatus.CompileError },
-      { status: MutantStatus.Killed },
-      { status: MutantStatus.NoCoverage },
-      { status: MutantStatus.RuntimeError },
-      { status: MutantStatus.Survived },
-      { status: MutantStatus.Timeout }
-    ];
-    await sut.updateComplete;
-    const actualCheckboxes = sut.$$('.form-check.form-check-inline');
-    expect(actualCheckboxes).lengthOf(6);
-    const checkboxTexts = actualCheckboxes.map(checkbox => normalizeWhitespace((checkbox.textContent as string)));
-    expect(checkboxTexts).deep.eq([
-      '✅ Killed (1)',
-      '👽 Survived (1)',
-      '🙈 NoCoverage (1)',
-      '⌛ Timeout (1)',
-      '💥 CompileError (1)',
-      '💥 RuntimeError (1)'
-    ]);
-  });
-
-  it('should show the correct colors for the states', async () => {
-    // Arrange
-    sut.element.mutants = [
-      { status: MutantStatus.CompileError },
-      { status: MutantStatus.Killed },
-      { status: MutantStatus.NoCoverage },
-      { status: MutantStatus.RuntimeError },
-      { status: MutantStatus.Survived },
-      { status: MutantStatus.Timeout }
-    ];
-
-    // Act
-    await sut.updateComplete;
-
-    // Assert
-    function assertColor(status: string, expectedColor: string) {
-      expect(getComputedStyle(sut.$(`[data-status=${status}] .badge`)).backgroundColor).eq(expectedColor);
-    }
-    Object.keys(expectedMutantColors).forEach(status => {
-      assertColor(status, expectedMutantColors[status as  MutantStatus]);
+    it('should display no checkboxes without mutants', () => {
+      expect(sut.$$('input[checkbox]')).lengthOf(0);
     });
-  });
 
-  it('should dispatch the "filters-changed" event for the initial state', async () => {
+    it('should display checkboxes for all states', async () => {
+      sut.element.mutants = [
+        { status: MutantStatus.CompileError },
+        { status: MutantStatus.Killed },
+        { status: MutantStatus.NoCoverage },
+        { status: MutantStatus.RuntimeError },
+        { status: MutantStatus.Survived },
+        { status: MutantStatus.Timeout }
+      ];
+      await sut.updateComplete;
+      const actualCheckboxes = sut.$$('.form-check.form-check-inline');
+      expect(actualCheckboxes).lengthOf(6);
+      const checkboxTexts = actualCheckboxes.map(checkbox => normalizeWhitespace((checkbox.textContent as string)));
+      expect(checkboxTexts).deep.eq([
+        '✅ Killed (1)',
+        '👽 Survived (1)',
+        '🙈 NoCoverage (1)',
+        '⌛ Timeout (1)',
+        '💥 CompileError (1)',
+        '💥 RuntimeError (1)'
+      ]);
+    });
+
+    Object.keys(expectedMutantColors).forEach(status => {
+      it(`should render correct badge color for ${status} mutant`, async () => {
+        // Arrange
+        const mutantStatus = (status as MutantStatus);
+        const expectedColor = expectedMutantColors[mutantStatus];
+        sut.element.mutants = [
+          { status: mutantStatus }
+        ];
+
+        // Act
+        await sut.updateComplete;
+
+        // Assert
+        const badge = sut.$(`[data-status=${status}] .badge`);
+        expect(getComputedStyle(badge).backgroundColor).eq(expectedColor);
+      });
+    });
+
+    it('should dispatch the "filters-changed" event for the initial state', async () => {
       let actualEvent: CustomEvent | undefined;
       sut.element.addEventListener('filters-changed', (ev: any) => actualEvent = ev);
       sut.element.mutants = [
@@ -92,7 +87,7 @@ describe(MutationTestReportFileLegendComponent.name, () => {
       expect((actualEvent as CustomEvent).detail).deep.eq(expected);
     });
 
-  it('should dispatch the "filters-changed" event when a checkbox is checked', async () => {
+    it('should dispatch the "filters-changed" event when a checkbox is checked', async () => {
       // Arrange
       sut.element.mutants = [
         { status: MutantStatus.CompileError },

--- a/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/components/mutation-test-report-file.spec.ts
@@ -3,7 +3,7 @@ import { MutationTestReportFileComponent } from '../../../src/components/mutatio
 import { expect } from 'chai';
 import { FileResult, MutantStatus, MutantResult } from 'mutation-testing-report-schema';
 import { MutationTestReportMutantComponent, SHOW_MORE_EVENT } from '../../../src/components/mutation-test-report-mutant';
-import { MutationTestReportFileLegendComponent, MutantFilter } from '../../../src/components/mutation-test-report-file-legend';
+import { MutationTestReportFileLegendComponent, MutantFilter } from '../../../dist/components/mutation-test-report-file-legend';
 import { createFileResult } from '../../helpers/factory';
 import { MutationTestReportModalDialogComponent } from '../../../dist/components/mutation-test-report-modal-dialog';
 
@@ -111,7 +111,7 @@ describe(MutationTestReportFileComponent.name, () => {
         const dialog = sut.$('mutation-test-report-modal-dialog') as MutationTestReportModalDialogComponent;
 
         // Assert
-        expect(dialog.header).eq(`30: testMutator - ✔ Killed`);
+        expect(dialog.header).eq(`30: testMutator - ✅ Killed`);
       });
 
       it('should display the description in the dialog when it\'s opened', async () => {

--- a/packages/mutation-testing-elements/test/unit/components/mutation-test-report-mutant.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/components/mutation-test-report-mutant.spec.ts
@@ -2,6 +2,7 @@ import { MutationTestReportMutantComponent, SHOW_MORE_EVENT } from '../../../src
 import { CustomElementFixture } from '../helpers/CustomElementFixture';
 import { expect } from 'chai';
 import { MutantStatus, MutantResult } from 'mutation-testing-report-schema';
+import { expectedMutantColors } from '../../helpers/helperFunctions';
 
 describe(MutationTestReportMutantComponent.name, () => {
 
@@ -47,13 +48,16 @@ describe(MutationTestReportMutantComponent.name, () => {
     expect(sut.$('.replacement').hidden).true;
   });
 
-  it('should render correct badge color for mutant', async () => {
-    sut.element.show = true;
-    sut.element.mutant = createMutantResult({ status: MutantStatus.Survived });
-    await sut.updateComplete;
-    const badge = sut.$('span.badge');
-    expect(getComputedStyle(badge).background).match(/rgb\(220, 53, 69\)/);
-    expect(badge.innerText).eq(sut.element.mutant.id);
+  Object.keys(expectedMutantColors).forEach(status => {
+    it(`should render correct badge color for ${status} mutant`, async () => {
+      const actualMutantStatus = status as MutantStatus;
+      sut.element.show = true;
+      sut.element.mutant = createMutantResult({ status: actualMutantStatus });
+      await sut.updateComplete;
+      const badge = sut.$('span.badge');
+      expect(getComputedStyle(badge).backgroundColor).eq(expectedMutantColors[actualMutantStatus]);
+      expect(badge.innerText).eq(sut.element.mutant.id);
+    });
   });
 
   it('should render replacement when the button is clicked', async () => {

--- a/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
@@ -10,7 +10,7 @@ describe(getContextClassForStatus.name, () => {
   }
   actArrangeAssert('success', MutantStatus.Killed);
   actArrangeAssert('danger', MutantStatus.Survived);
-  actArrangeAssert('danger', MutantStatus.NoCoverage);
+  actArrangeAssert('caution', MutantStatus.NoCoverage);
   actArrangeAssert('warning', MutantStatus.Timeout);
   actArrangeAssert('secondary', MutantStatus.CompileError);
   actArrangeAssert('secondary', MutantStatus.RuntimeError);


### PR DESCRIPTION
This PR adds a new orange color to differentiate no-coverage from survived states more easily. This should make the report more in line with what PIT does with its line coverage. 

It also adds emojis to the mutant legends. Both are demoed here: 

![image](https://user-images.githubusercontent.com/1828233/59013551-7857a000-883a-11e9-97b2-d920183bd707.png)

