### PR TITLE
fix(popup): caution popup arrow color

### DIFF
--- a/packages/mutation-testing-elements/src/components/mutation-test-report-popup/mutation-test-report-popup.scss
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-popup/mutation-test-report-popup.scss
@@ -1,5 +1,5 @@
 @import "~bootstrap/scss/_functions.scss";
-@import "~bootstrap/scss/_variables.scss";
+@import "../../style/bootstrap-reboot.scss";
 
 :host {
     position: relative;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10114577/60756859-3bcac000-a003-11e9-8a05-cc6125541ab2.png)


After:
![image](https://user-images.githubusercontent.com/10114577/60756851-2190e200-a003-11e9-82c6-88e1bea27736.png)

Popup arrow is now also the correct color for cautions (and any other extra colors we might add in the future).