### PR TITLE
fix(links): use absolute urls inside the report

### DIFF
--- a/packages/mutation-testing-elements/src/components/mutation-test-report-breadcrumb.ts
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-breadcrumb.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, property, customElement } from 'lit-element';
 import { bootstrap } from '../style';
+import { toAbsoluteUrl } from '../lib/htmlHelpers';
 const ROOT_NAME = 'All files';
 
 @customElement('mutation-test-report-breadcrumb')
@@ -20,7 +21,7 @@ export class MutationTestReportBreadcrumbComponent extends LitElement {
 
   private renderRootItem() {
     if (this.path && this.path.length) {
-      return this.renderLink(ROOT_NAME, '#');
+      return this.renderLink(ROOT_NAME, '');
     } else {
       return this.renderActiveItem(ROOT_NAME);
     }
@@ -33,7 +34,7 @@ export class MutationTestReportBreadcrumbComponent extends LitElement {
         if (index === path.length - 1) {
           return this.renderActiveItem(item);
         } else {
-          return this.renderLink(item, `#${path.filter((_, i) => i <= index).join('/')}`);
+          return this.renderLink(item, `${path.filter((_, i) => i <= index).join('/')}`);
         }
       });
     }
@@ -45,6 +46,6 @@ export class MutationTestReportBreadcrumbComponent extends LitElement {
   }
 
   private renderLink(title: string, url: string) {
-    return html`<li class="breadcrumb-item"><a href="${url}">${title}</a></li>`;
+    return html`<li class="breadcrumb-item"><a href="${toAbsoluteUrl(url)}">${title}</a></li>`;
   }
 }

--- a/packages/mutation-testing-elements/src/components/mutation-test-report-totals.ts
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-totals.ts
@@ -4,6 +4,7 @@ import { Thresholds } from 'mutation-testing-report-schema';
 import * as svg from './svg';
 import { pathJoin } from '../lib/codeHelpers';
 import { MetricsResult } from 'mutation-testing-metrics';
+import { toAbsoluteUrl } from '../lib/htmlHelpers';
 
 @customElement('mutation-test-report-totals')
 export class MutationTestReportTotalsComponent extends LitElement {
@@ -149,7 +150,7 @@ export class MutationTestReportTotalsComponent extends LitElement {
     return html`
     <tr title="${row.name}">
       <td style="width: 17px;" class="icon no-border-right">${row.file ? svg.file : svg.directory}</td>
-      <td width="" class="no-border-left">${typeof path === 'string' ? html`<a href="${this.link(path)}">${name}</a>` :
+      <td width="" class="no-border-left">${typeof path === 'string' ? html`<a href="${toAbsoluteUrl(path)}">${name}</a>` :
         html`<span>${row.name}</span>`}</td>
       <td class="no-border-right vertical-middle">
         <div class="progress">
@@ -170,10 +171,6 @@ export class MutationTestReportTotalsComponent extends LitElement {
       <th class="text-center">${row.metrics.totalUndetected}</th>
       <th class="text-center">${row.metrics.totalMutants}</th>
     </tr>`;
-  }
-
-  private link(to: string) {
-    return `#${to}`;
   }
 
   private determineColoringClass(score: number) {

--- a/packages/mutation-testing-elements/src/lib/htmlHelpers.ts
+++ b/packages/mutation-testing-elements/src/lib/htmlHelpers.ts
@@ -40,3 +40,9 @@ export function escapeHtml(unsafe: string) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
 }
+
+export function toAbsoluteUrl(fragment: string): string {
+  // Use absolute url because of https://github.com/stryker-mutator/mutation-testing-elements/issues/53
+  const url = new URL(window.location.href);
+  return new URL(`#${fragment}`, url).href;
+}

--- a/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, getContextClassForStatus } from '../../../src/lib/htmlHelpers';
+import { escapeHtml, getContextClassForStatus, toAbsoluteUrl } from '../../../src/lib/htmlHelpers';
 import { expect } from 'chai';
 import { MutantStatus } from 'mutation-testing-report-schema';
 
@@ -28,4 +28,12 @@ describe(escapeHtml.name, () => {
   actArrangeAssert('foo>bar', 'foo&gt;bar');
   actArrangeAssert('foo"bar', 'foo&quot;bar');
   actArrangeAssert('foo\'bar', 'foo&#039;bar');
+});
+
+describe(toAbsoluteUrl.name, () => {
+
+  it('should make a fragment absolute', () => {
+    const actual = toAbsoluteUrl('foo');
+    expect(actual).eq(window.location.href + '#foo');
+  });
 });

--- a/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/lib/htmlHelpers.spec.ts
@@ -31,9 +31,17 @@ describe(escapeHtml.name, () => {
 });
 
 describe(toAbsoluteUrl.name, () => {
-
   it('should make a fragment absolute', () => {
     const actual = toAbsoluteUrl('foo');
-    expect(actual).eq(window.location.href + '#foo');
+    expect(actual).eq(expectedUrl());
+
+    function expectedUrl() {
+      const currentUrl = window.location.href;
+      if (currentUrl.endsWith('#')) {
+        return `${currentUrl}foo`;
+      } else {
+        return `${currentUrl}#foo`;
+      }
+    }
   });
 });

--- a/packages/mutation-testing-elements/testResources/scala-example/index.html
+++ b/packages/mutation-testing-elements/testResources/scala-example/index.html
@@ -2,6 +2,11 @@
 
 <head>
     <title>Simple example - Mutation test elements</title>
+    <!-- 
+      The `<base>` tag should be circumvented using absolute URL's.
+      reproduce issue https://github.com/stryker-mutator/mutation-testing-elements/issues/53 
+    -->
+    <base href="/">
 </head>
 
 <body>


### PR DESCRIPTION
Make sure to support HTML documents that have set a `<base>` HTML tag. Use absolute urls constructed based on the current document, instead of the base.

Fixes #53 