### PR TITLE
feat(build): use Terser plugin for smaller bundle

### DIFF
--- a/packages/mutation-testing-elements/webpack.common.js
+++ b/packages/mutation-testing-elements/webpack.common.js
@@ -1,5 +1,4 @@
 const path = require('path');
-// const TerserPlugin = require('terser-webpack-plugin');
 const context = __dirname;
 module.exports = {
   entry: './src/index.ts',

--- a/packages/mutation-testing-elements/webpack.dev.js
+++ b/packages/mutation-testing-elements/webpack.dev.js
@@ -8,4 +8,3 @@ module.exports = merge(common, {
     contentBase: ['./testResources', '.']
   }
 });
-

--- a/packages/mutation-testing-elements/webpack.prod.js
+++ b/packages/mutation-testing-elements/webpack.prod.js
@@ -1,6 +1,11 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = merge(common, {
-  mode: 'production'
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin()],
+  }
 });


### PR DESCRIPTION
Nothing earth-shattering. But using the Terser plugin shrinks the bundle from 378KB to 368KB. So why not use it?