### PR TITLE
build(optimize): remove lodash.groupby

### DIFF
--- a/packages/mutation-testing-elements/package-lock.json
+++ b/packages/mutation-testing-elements/package-lock.json
@@ -3,27 +3,5 @@
   "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
-  "dependencies": {
-    "@types/lodash": {
-      "version": "4.14.135",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.135.tgz",
-      "integrity": "sha512-Ed+tSZ9qM1oYpi5kzdsBuOzcAIn1wDW+e8TFJ50IMJMlSopGdJgKAbhHzN6h1E1OfjlGOr2JepzEWtg9NIfoNg==",
-      "dev": true
-    },
-    "@types/lodash.groupby": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
-      "integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
-      "dev": true
-    }
-  }
+  "dependencies": {}
 }

--- a/packages/mutation-testing-elements/package.json
+++ b/packages/mutation-testing-elements/package.json
@@ -24,8 +24,6 @@
   },
   "homepage": "https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-elements#readme",
   "devDependencies": {
-    "@types/lodash.groupby": "^4.6.6",
-    "lodash.groupby": "^4.6.0",
     "mutation-testing-metrics": "^1.2.2",
     "mutation-testing-report-schema": "^1.2.0"
   }

--- a/packages/mutation-testing-metrics/package-lock.json
+++ b/packages/mutation-testing-metrics/package-lock.json
@@ -3,26 +3,5 @@
   "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
-  "dependencies": {
-    "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
-      "dev": true
-    },
-    "@types/lodash.groupby": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
-      "integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
-    }
-  }
+  "dependencies": {}
 }

--- a/packages/mutation-testing-metrics/package.json
+++ b/packages/mutation-testing-metrics/package.json
@@ -18,10 +18,7 @@
   },
   "homepage": "https://github.com/stryker-mutator/mutation-testing-elements/tree/master/packages/mutation-testing-metrics#readme",
   "dependencies": {
-    "lodash.groupby": "^4.6.0",
     "mutation-testing-report-schema": "^1.2.0"
   },
-  "devDependencies": {
-    "@types/lodash.groupby": "^4.6.6"
-  }
+  "devDependencies": {}
 }

--- a/packages/mutation-testing-metrics/src/calculateMetrics.ts
+++ b/packages/mutation-testing-metrics/src/calculateMetrics.ts
@@ -1,6 +1,6 @@
 import { compareNames, normalizeFileNames, flatMap } from './helpers';
 import { FileResultDictionary, FileResult, MutantResult, MutantStatus } from 'mutation-testing-report-schema';
-import groupBy from 'lodash.groupby';
+import { groupBy } from './helpers';
 import { Metrics } from './api/Metrics';
 import { MetricsResult } from './api/MetricsResult';
 const DEFAULT_SCORE = 100;

--- a/packages/mutation-testing-metrics/src/helpers.ts
+++ b/packages/mutation-testing-metrics/src/helpers.ts
@@ -8,21 +8,16 @@ export function flatMap<T, R>(source: T[], fn: (input: T) => R[]) {
   return result;
 }
 
-type Dictionary<T> = Record<string, [string,T][]>;
-
-export function groupBy<T>(arr: [string,T][], criteria: (t: [string,T]) => string): Dictionary<T> {
-  return arr.reduce(
-    (obj: Dictionary<T>, item) => {
-      const key = criteria(item);
-      if (!obj.hasOwnProperty(key)) {
-        obj[key] = [];
-      }
-      obj[key].push(item);
-      return obj;
-    },
-    {}
-  )
-};
+export function groupBy<T>(arr: T[], criteria: (element: T) => string): Record<string, T[]> {
+  return arr.reduce((acc: Record<string, T[]>, item) => {
+    const key = criteria(item);
+    if (!acc.hasOwnProperty(key)) {
+      acc[key] = [];
+    }
+    acc[key].push(item);
+    return acc;
+  }, {});
+}
 
 export function pathJoin(...parts: string[]) {
   return parts.reduce((prev, current) => prev.length ? current ? `${prev}/${current}` : prev : current, '');

--- a/packages/mutation-testing-metrics/src/helpers.ts
+++ b/packages/mutation-testing-metrics/src/helpers.ts
@@ -8,6 +8,22 @@ export function flatMap<T, R>(source: T[], fn: (input: T) => R[]) {
   return result;
 }
 
+type Dictionary<T> = Record<string, [string,T][]>;
+
+export function groupBy<T>(arr: [string,T][], criteria: (t: [string,T]) => string): Dictionary<T> {
+  return arr.reduce(
+    (obj: Dictionary<T>, item) => {
+      const key = criteria(item);
+      if (!obj.hasOwnProperty(key)) {
+        obj[key] = [];
+      }
+      obj[key].push(item);
+      return obj;
+    },
+    {}
+  )
+};
+
 export function pathJoin(...parts: string[]) {
   return parts.reduce((prev, current) => prev.length ? current ? `${prev}/${current}` : prev : current, '');
 }


### PR DESCRIPTION
Having a small helper function for groupBy instead of the `lodash.groupby` dependency shrinks the bundle from 234Kb to 222Kb