### PR TITLE
fix: font styling being excluded by postcss

### DIFF
--- a/packages/mutation-testing-elements/postcss.config.js
+++ b/packages/mutation-testing-elements/postcss.config.js
@@ -7,7 +7,7 @@ module.exports = {
     require('@fullhuman/postcss-purgecss')({
       content: ['src/**/*.ts'],
       // Don't purge dynamically added classes
-      whitelistPatterns: [/^(bg|badge|popover|text)-(success|caution|danger|warning|secondary|default)(-light)?$/, /^lang-/, /^hljs/]
+      whitelistPatterns: [/^(bg|badge|popover|text)-(success|caution|danger|warning|secondary|default)(-light)?$/, /^lang-/, /^hljs/, /^:host$/]
     })
   ]
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10114577/73382811-832edb80-42c8-11ea-8b44-1a6de570b65e.png)


After:
![image](https://user-images.githubusercontent.com/10114577/73382723-5f6b9580-42c8-11ea-90bd-63f8aa99915e.png)
