### PR TITLE
feat(elements): support syntax highlighting for php

### DIFF
--- a/packages/mutation-testing-elements/src/components/mutation-test-report-file/index.ts
+++ b/packages/mutation-testing-elements/src/components/mutation-test-report-file/index.ts
@@ -6,7 +6,7 @@ import { bootstrap, prismjs } from '../../style';
 import { renderCode } from '../../lib/codeHelpers';
 import { FileResult, MutantResult } from 'mutation-testing-report-schema';
 import { getEmojiForStatus } from '../../lib/htmlHelpers';
-import { highlightElement, plugins } from 'prismjs/components/prism-core';
+import { highlightElement } from 'prismjs/components/prism-core';
 
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 // Order is important here! Scala depends on java, which depends on clike
@@ -17,11 +17,14 @@ import 'prismjs/components/prism-csharp';
 import 'prismjs/components/prism-java';
 import 'prismjs/components/prism-scala';
 
+// Markup and markup-templating are needed for php
+import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-php';
+
 // Don't strip pre-existing HTML to keep the popups and badges working
 import 'prismjs/plugins/keep-markup/prism-keep-markup';
-// Attempt to automatically download languages that are not already included above
-import 'prismjs/plugins/autoloader/prism-autoloader';
-plugins.autoloader.languages_path = `https://unpkg.com/prismjs@latest/components/`;
+// Removed auto-loader plugin because of https://github.com/stryker-mutator/mutation-testing-elements/issues/393
 
 @customElement('mutation-test-report-file')
 export class MutationTestReportFileComponent extends LitElement {

--- a/packages/mutation-testing-elements/test/integration/phpReport.it.spec.ts
+++ b/packages/mutation-testing-elements/test/integration/phpReport.it.spec.ts
@@ -1,0 +1,24 @@
+import { ReportPage } from './po/ReportPage';
+import { getCurrent } from './lib/browser';
+import { expect } from 'chai';
+
+describe.only('File report "infection-php-example/TextFileLogger.php"', () => {
+
+  let page: ReportPage;
+
+  before(async () => {
+    page = new ReportPage(getCurrent());
+    await page.navigateTo('');
+    await page.navigateTo('infection-php-example/#TextFileLogger.php');
+  });
+
+  it('should highlight the code', async() => {
+    expect(await page.isCodeHighlighted()).true;
+  });
+
+  it('should show mutants', async() => {
+    // Wait for code to be highted first
+    expect(await page.isCodeHighlighted()).true;
+    expect(await page.mutant('ebf143eb565188ddd7959bfbe70f631f').isButtonVisible()).true;
+  });
+});

--- a/packages/mutation-testing-elements/test/integration/po/ElementSelector.po.ts
+++ b/packages/mutation-testing-elements/test/integration/po/ElementSelector.po.ts
@@ -1,6 +1,7 @@
 import { ElementFinder } from './ElementFinder';
 import { WebElement, By, WebElementPromise } from 'selenium-webdriver';
 import { selectShadowRoot, wrapInWebElementPromise } from '../lib/helpers';
+import { getCurrent } from '../lib/browser';
 
 export class ElementSelector {
   constructor(private readonly context: ElementFinder) { }
@@ -17,6 +18,25 @@ export class ElementSelector {
       const context = await this.findContext(parts.slice(0, parts.length - 1));
       return context.findElement(By.css(parts[parts.length - 1]));
     });
+  }
+
+  /**
+   * Waits a bit for an element to become present. If not resolves false.
+   * @param cssSelector The css selector (can contain shadow selector `>>>`)
+   */
+  public async isPresent(cssSelector: string): Promise<boolean> {
+    const step = 100;
+    const seconds = 3;
+    const maxAttempts = seconds * 1000 / step;
+    for (let attempts = 0; attempts < maxAttempts; attempts++) {
+      try {
+        await this.$(cssSelector);
+        return true;
+      } catch {
+        await getCurrent().sleep(step);
+      }
+    }
+    return false;
   }
 
   private async findContext(webComponentPath: string[]) {

--- a/packages/mutation-testing-elements/test/integration/po/ReportPage.ts
+++ b/packages/mutation-testing-elements/test/integration/po/ReportPage.ts
@@ -31,12 +31,16 @@ export class ReportPage extends ElementSelector {
     return this.$('mutation-test-report-app >>> mutation-test-report-file >>> code').click();
   }
 
+  public async isCodeHighlighted(): Promise<boolean> {
+    return this.isPresent('mutation-test-report-app >>> mutation-test-report-file >>> code span.token');
+  }
+
   public async mutants(): Promise<MutantComponent[]> {
     return Promise.all((await this.$$('mutation-test-report-app >>> mutation-test-report-file >>> mutation-test-report-mutant'))
       .map(async host => new MutantComponent(await selectShadowRoot(host), this.browser)));
   }
 
-  public mutant(mutantId: number) {
+  public mutant(mutantId: number | string) {
     const shadowRoot = selectShadowRoot(
       this.$(`mutation-test-report-app >>> mutation-test-report-file >>> mutation-test-report-mutant[mutant-id="${mutantId}"]`));
     return new MutantComponent(shadowRoot, this.browser);

--- a/packages/mutation-testing-elements/testResources/index.html
+++ b/packages/mutation-testing-elements/testResources/index.html
@@ -21,6 +21,7 @@
                     <a class="list-group-item list-group-item-action" href="/scala-example">Scala example</a>
                     <a class="list-group-item list-group-item-action" href="/deep-dir-example">Deep dir example</a>
                     <a class="list-group-item list-group-item-action" href="/pitest-example">Pitest example</a>
+                    <a class="list-group-item list-group-item-action" href="/infection-php-example">InfectionPHP example</a>
                 </div>
             </div>
         </div>

--- a/packages/mutation-testing-elements/testResources/infection-php-example/index.html
+++ b/packages/mutation-testing-elements/testResources/infection-php-example/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <mutation-test-report-app title-postfix="InfectionPHP" src="report.json"></mutation-test-report-app>
+  <script src="/mutation-test-elements.js"></script>
+</body>
+</html>

--- a/packages/mutation-testing-elements/testResources/infection-php-example/report.json
+++ b/packages/mutation-testing-elements/testResources/infection-php-example/report.json
@@ -1,0 +1,236 @@
+{
+    "schemaVersion": 1,
+    "mutationScore": 53.84615384615385,
+    "thresholds": {
+        "low": 20,
+        "high": 80
+    },
+    "files": {
+        "\/Users\/tfidry\/Project\/Humbug\/infection\/src\/Logger\/TextFileLogger.php": {
+            "language": "php",
+            "source": "<?php\n\/**\n * This code is licensed under the BSD 3-Clause License.\n *\n * Copyright (c) 2017, Maks Rafalko\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions are met:\n *\n * * Redistributions of source code must retain the above copyright notice, this\n *   list of conditions and the following disclaimer.\n *\n * * Redistributions in binary form must reproduce the above copyright notice,\n *   this list of conditions and the following disclaimer in the documentation\n *   and\/or other materials provided with the distribution.\n *\n * * Neither the name of the copyright holder nor the names of its\n *   contributors may be used to endorse or promote products derived from\n *   this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\n * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\n * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\n * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\n * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\n * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\n * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n *\/\n\ndeclare(strict_types=1);\n\nnamespace Infection\\Logger;\n\nuse function array_map;\nuse function explode;\nuse function implode;\nuse Infection\\Mutant\\MetricsCalculator;\nuse Infection\\Mutant\\MutantExecutionResult;\nuse Infection\\Str;\nuse const PHP_EOL;\nuse function Safe\\sprintf;\nuse function str_repeat;\nuse function strlen;\n\n\/**\n * @internal\n *\/\nfinal class TextFileLogger implements LineMutationTestingResultsLogger\n{\n    private $metricsCalculator;\n    private $debugVerbosity;\n    private $onlyCoveredMode;\n    private $debugMode;\n\n    public function __construct(\n        MetricsCalculator $metricsCalculator,\n        bool $debugVerbosity,\n        bool $onlyCoveredMode,\n        bool $debugMode\n    ) {\n        $this->metricsCalculator = $metricsCalculator;\n        $this->debugVerbosity = $debugVerbosity;\n        $this->onlyCoveredMode = $onlyCoveredMode;\n        $this->debugMode = $debugMode;\n    }\n\n    public function getLogLines(): array\n    {\n        $separateSections = false;\n\n        $logs[] = $this->getResultsLine(\n            $this->metricsCalculator->getEscapedExecutionResults(),\n            'Escaped',\n            $separateSections\n        );\n        $logs[] = $this->getResultsLine(\n            $this->metricsCalculator->getTimedOutExecutionResults(),\n            'Timed Out',\n            $separateSections\n        );\n\n        if ($this->debugVerbosity) {\n            $logs[] = $this->getResultsLine(\n                $this->metricsCalculator->getKilledExecutionResults(),\n                'Killed',\n                $separateSections\n            );\n            $logs[] = $this->getResultsLine(\n                $this->metricsCalculator->getErrorExecutionResults(),\n                'Errors',\n                $separateSections\n            );\n        }\n\n        if (!$this->onlyCoveredMode) {\n            $logs[] = $this->getResultsLine(\n                $this->metricsCalculator->getNotCoveredExecutionResults(),\n                'Not Covered',\n                $separateSections\n            );\n        }\n\n        if ($separateSections) {\n            $logs[] = '';\n        }\n\n        return $logs;\n    }\n\n    \/**\n     * @param MutantExecutionResult[] $executionResults\n     *\/\n    private function getResultsLine(\n        array $executionResults,\n        string $headlinePrefix,\n        bool &$separateSections\n    ): string {\n        $lines = [];\n\n        if ($separateSections) {\n            $lines[] = '';\n            $lines[] = '';\n        }\n\n        $lines[] = self::getHeadlineLines($headlinePrefix);\n\n        $separateSections = false;\n\n        foreach ($executionResults as $index => $executionResult) {\n            if ($separateSections) {\n                $lines[] = '';\n                $lines[] = '';\n            }\n\n            $lines[] = self::getMutatorLine($index, $executionResult);\n            $lines[] = '';\n            $lines[] = Str::trimLineReturns($executionResult->getMutationDiff());\n\n            if ($this->debugMode) {\n                $lines[] = '';\n                $lines[] = '$ ' . $executionResult->getProcessCommandLine();\n            }\n\n            if ($this->debugVerbosity) {\n                if (!$this->debugMode) {\n                    $lines[] = '';\n                }\n\n                $lines[] = self::getProcessOutputLine($executionResult->getProcessOutput());\n            }\n\n            $separateSections = true;\n        }\n\n        return implode(PHP_EOL, $lines);\n    }\n\n    private static function getHeadlineLines(string $headlinePrefix): string\n    {\n        $headline = sprintf('%s mutants:', $headlinePrefix);\n\n        return implode(\n            PHP_EOL,\n            [\n                $headline,\n                str_repeat('=', strlen($headline)),\n                '',\n            ]\n        );\n    }\n\n    private static function getMutatorLine(int $index, MutantExecutionResult $mutantProcess): string\n    {\n        return sprintf(\n            '%d) %s:%d    [M] %s',\n            $index + 1,\n            $mutantProcess->getOriginalFilePath(),\n            $mutantProcess->getOriginalStartingLine(),\n            $mutantProcess->getMutatorName()\n        );\n    }\n\n    private static function getProcessOutputLine(string $value): string\n    {\n        return implode(\n            PHP_EOL,\n            array_map(\n                static function (string $line): string {\n                    return '  ' . $line;\n                },\n                explode(PHP_EOL, Str::trimLineReturns($value))\n            )\n        );\n    }\n}\n",
+            "mutants": [
+                {
+                    "id": "49e4c033e82152deffaff902aa51ac0e",
+                    "mutatorName": "FalseValue",
+                    "replacement": "true",
+                    "location": {
+                        "start": {
+                            "line": 73,
+                            "column": 29
+                        },
+                        "end": {
+                            "line": 73,
+                            "column": 34
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "20a5ecac3e1b72a7e9165b2561d915f6",
+                    "mutatorName": "LogicalNot",
+                    "replacement": "        if ($this->onlyCoveredMode) {",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 99,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 99,
+                            "column": 39
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "38059b5b328cbcf554448979bd91f0a0",
+                    "mutatorName": "ArrayOneItem",
+                    "replacement": "        return count($logs) > 1 ? array_slice($logs, 0, 1, true) : $logs;",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 111,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 111,
+                            "column": 75
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "a75a4009b933f26f9c429376eddd3523",
+                    "mutatorName": "FalseValue",
+                    "replacement": "        $separateSections = true;",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 131,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 131,
+                            "column": 35
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "3de83231228d28dd3a9a8fd29dc27e16",
+                    "mutatorName": "Foreach_",
+                    "replacement": "        foreach (array() as $index => $executionResult) {",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 133,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 157,
+                            "column": 59
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "ebf143eb565188ddd7959bfbe70f631f",
+                    "mutatorName": "LogicalNot",
+                    "replacement": "                if ($this->debugMode) {",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 149,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 149,
+                            "column": 41
+                        }
+                    },
+                    "status": "NoCoverage"
+                },
+                {
+                    "id": "78df83645d5862a489725a1ca83c2e46",
+                    "mutatorName": "TrueValue",
+                    "replacement": "            $separateSections = false;",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 156,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 156,
+                            "column": 40
+                        }
+                    },
+                    "status": "NoCoverage"
+                },
+                {
+                    "id": "f846f1fb950a4effa3412240e7f47824",
+                    "mutatorName": "ArrayItemRemoval",
+                    "replacement": "        return implode(PHP_EOL, [str_repeat('=', strlen($headline)), '']);",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 168,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 172,
+                            "column": 76
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "8054ad82df5a2551ed9626773f43a04d",
+                    "mutatorName": "UnwrapStrRepeat",
+                    "replacement": "        return implode(PHP_EOL, [$headline, '=', '']);",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 170,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 170,
+                            "column": 56
+                        }
+                    },
+                    "status": "Killed"
+                },
+                {
+                    "id": "bf33233e4af421b6a9847e7e74496280",
+                    "mutatorName": "IncrementInteger",
+                    "replacement": "        return sprintf('%d) %s:%d    [M] %s', $index + 2, $mutantProcess->getOriginalFilePath(), $mutantProcess->getOriginalStartingLine(), $mutantProcess->getMutatorName());",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 180,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 180,
+                            "column": 176
+                        }
+                    },
+                    "status": "NoCoverage"
+                },
+                {
+                    "id": "2b8250c49e391d4977b8845335444060",
+                    "mutatorName": "OneZeroInteger",
+                    "replacement": "        return sprintf('%d) %s:%d    [M] %s', $index + 0, $mutantProcess->getOriginalFilePath(), $mutantProcess->getOriginalStartingLine(), $mutantProcess->getMutatorName());",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 180,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 180,
+                            "column": 176
+                        }
+                    },
+                    "status": "NoCoverage"
+                },
+                {
+                    "id": "69422fbd0d5e80c9838c02bacc4e280f",
+                    "mutatorName": "Plus",
+                    "replacement": "        return sprintf('%d) %s:%d    [M] %s', $index - 1, $mutantProcess->getOriginalFilePath(), $mutantProcess->getOriginalStartingLine(), $mutantProcess->getMutatorName());",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 180,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 180,
+                            "column": 176
+                        }
+                    },
+                    "status": "NoCoverage"
+                },
+                {
+                    "id": "2e34f5a6b5f690e84959724852b8a05c",
+                    "mutatorName": "UnwrapArrayMap",
+                    "replacement": "        return implode(PHP_EOL, explode(PHP_EOL, Str::trimLineReturns($value)));",
+                    "description": "yo",
+                    "location": {
+                        "start": {
+                            "line": 191,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 196,
+                            "column": 82
+                        }
+                    },
+                    "status": "NoCoverage"
+                }
+            ]
+        }
+    }
+}

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -26,12 +26,14 @@
       "source.fixAll.tslint": true
     },
     "typescript.tsdk": "./node_modules/typescript/lib",
-    "search.usePCRE2": true,
     "grunt.autoDetect": "off",
     "gulp.autoDetect": "off",
     "jake.autoDetect": "off",
-    "task.autoDetect": "off"
+    "task.autoDetect": "off",
+    "cSpell.words": [
+      "clike",
+      "prismjs",
+      "templating"
+    ]
   }
-}
-}
 }


### PR DESCRIPTION
Disable automatic loading of syntax highlight settings for unknown languages.
Include PHP in the supported languages.

Workaround for #393 