### PR TITLE
fix(sonatype): fix release process for sonatype

### DIFF
--- a/packages/mutation-testing-metrics-scala/build.sbt
+++ b/packages/mutation-testing-metrics-scala/build.sbt
@@ -1,4 +1,4 @@
-val Scala212 = "2.12.10"
+val Scala212 = "2.12.11"
 val Scala213 = "2.13.1"
 
 scalaVersion := Scala213
@@ -19,7 +19,7 @@ lazy val circe = project
     libraryDependencies ++= Seq(
       "io.circe"             %% "circe-core"   % "0.13.0",
       "io.circe"             %% "circe-parser" % "0.13.0",
-      "org.leadpony.justify" % "justify"       % "2.0.0" % Test,
+      "org.leadpony.justify" % "justify"       % "2.1.0" % Test,
       "org.leadpony.joy"     % "joy"           % "1.3.0" % Test
     )
   )

--- a/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/DecoderTest.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/DecoderTest.scala
@@ -1,5 +1,0 @@
-package mutationtesting
-
-import verify._
-
-object DecoderTest extends BasicTestSuite {}

--- a/packages/mutation-testing-metrics-scala/npmProjPublish.sh
+++ b/packages/mutation-testing-metrics-scala/npmProjPublish.sh
@@ -18,4 +18,4 @@ mkdir -p $SBT_RESOURCES_DIR
 echo "Copying $DIST_BASE files to resources"
 cp -r $DIST_DIR $SBT_RESOURCES_DIR/$PROJ_BASE
 
-sbt "+publishSigned; sonatypeBundleRelease"
+sbt "sonatypeBundleClean; +publishSigned; sonatypeBundleRelease"

--- a/packages/mutation-testing-metrics-scala/project/plugins.sbt
+++ b/packages/mutation-testing-metrics-scala/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.0.1")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.1.1")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.1.5")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.11")
 


### PR DESCRIPTION
Publishes for mutation-testing-elements and mutation-testing-report-schema to Sonatype were broken since #356.

The reason for this is that sbt-sonatype prepares the files to be uploaded in a directory, and then batch uploads them to sonatype. When the base project is released, this works fine. However, the files will still be present after publishing. Then, when elements or report-schema is trying to be uploaded sbt-sonatype will also attempt to upload the files that are still there from the previous publish. Because releases on sonatype are immutable, this returns an error (`Repository ='releases:Releases' does not allow updating artifact='/io/stryker-mutator/mutation-testing-metrics-circe_2.12/1.3.1/mutation-testing-metrics-circe_2.12-1.3.1.pom'`).

This is similar to https://github.com/olafurpg/sbt-ci-release/issues/87

This PR applies a similar fix, the old files are cleaned before publishing the new ones

For the 1.3.1 release, I have manually released them and the artifacts should be available soon