### PR TITLE
Improve performance of report-mutant rendering

### DIFF
--- a/packages/mutation-testing-elements/src/lib/codeHelpers.ts
+++ b/packages/mutation-testing-elements/src/lib/codeHelpers.ts
@@ -26,19 +26,16 @@ export function renderCode(model: FileResult): string {
     startedMutants.push(...currentMutants);
 
     const builder: string[] = [];
-    if (currentMutants.length || mutantsEnding.length) {
-      currentMutants.forEach(backgroundState.markMutantStart);
-      mutantsEnding.forEach(backgroundState.markMutantEnd);
-
-      // End previous color span
+    if (mutantsEnding.length) {
       builder.push('</span>');
+      mutantsEnding.forEach(backgroundState.markMutantEnd);
+    }
 
-      // End mutants
-      mutantsEnding.forEach(() => builder.push('</mutation-test-report-mutant>'));
+    if (currentMutants.length) {
+      currentMutants.forEach(backgroundState.markMutantStart);
 
-      // Start mutants
-      currentMutants.forEach((mutant) => builder.push(`<mutation-test-report-mutant mutant-id="${mutant.id}">`));
-
+      // Write mutants
+      currentMutants.forEach((mutant) => builder.push(`<mutation-test-report-mutant mutant-id="${mutant.id}"></mutation-test-report-mutant>`));
       // Start new color span
       builder.push(`<span class="bg-${backgroundState.determineBackground()}">`);
     }

--- a/packages/mutation-testing-elements/test/unit/lib/helpers.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/lib/helpers.spec.ts
@@ -35,7 +35,7 @@ describe(renderCode.name, () => {
     };
     const actualCode = renderCode(input);
     expect(actualCode).eq(
-      '<span>const foo = &#039;</span><mutation-test-report-mutant mutant-id="1"><span class="bg-success-light">bar</span></mutation-test-report-mutant><span class="bg-null">&#039;;\n\nfunction add(a, b) {\n  return a + b;\n}</span>'
+      '<span>const foo = &#039;<mutation-test-report-mutant mutant-id="1"></mutation-test-report-mutant><span class="bg-success-light">bar</span>&#039;;\n\nfunction add(a, b) {\n  return a + b;\n}</span>'
     );
   });
 
@@ -67,7 +67,7 @@ describe(renderCode.name, () => {
         .trim(), // strip the padding left
     };
     const actualCode = renderCode(input);
-    expect(actualCode).include('<mutation-test-report-mutant mutant-id="1"><span class="bg-success-light">add</span></mutation-test-report-mutant>');
-    expect(actualCode).include('<mutation-test-report-mutant mutant-id="2"><span class="bg-danger-light">;\n</span></mutation-test-report-mutant>');
+    expect(actualCode).include('<mutation-test-report-mutant mutant-id="1"></mutation-test-report-mutant><span class="bg-success-light">add</span>');
+    expect(actualCode).include('<mutation-test-report-mutant mutant-id="2"></mutation-test-report-mutant><span class="bg-danger-light">;\n</span>');
   });
 });


### PR DESCRIPTION
(Hopefully) partially fixes #423

I noticed that if there are multiple mutations on the same location the `mutation-test-report-mutant` was rendered in a nested structure. So each report-mutant element is rendered **inside** the one that went before it. This makes the whole report nested, and with a large amount of mutants on the same location this has a big impact on performance.

With this change report-mutants are rendered in a flat structure, instead of nested for each mutant. The browser is much more efficient at rendering this. And it looks like lit-html deals with it a bit more efficiently, too.

I also cleaned up the rendering code a little to no longer add or close spans when it shouldn't. So we don't have to rely on the mercy of how browsers decide to clean up our invalid HTML.

### Previous:

![image](https://user-images.githubusercontent.com/10114577/83974119-2a60f680-a8eb-11ea-825e-71c4389070ca.png)

Etcetera. You get the picture.

### New:

![image](https://user-images.githubusercontent.com/10114577/83974013-752e3e80-a8ea-11ea-94bd-24fbf351edca.png)

In Chromium Edge, this speeds up a report with 1000 mutants on the same location from ~50 seconds of an unresponsive white page to ~9.

EDIT: Unfortunately this breaks the line-through when you open a mutant. I'll see if I can fix that