### PR TITLE
fix(sonatype): give elements and report-schema their own sonatype version

### DIFF
--- a/packages/mutation-testing-elements/package.json
+++ b/packages/mutation-testing-elements/package.json
@@ -12,7 +12,8 @@
     "test:unit": "karma start --singleRun true",
     "test:integration": "mocha --forbid-only --forbid-pending -r ts-node/register -r chromedriver --timeout 60000 --file test/integration/init/init-browser.ts --file test/integration/init/init-server.ts test/integration/*.ts",
     "postpublish": "PUBLISH_ELEMENTS=true ../mutation-testing-metrics-scala/npmProjPublish.sh",
-    "stryker": "cross-env STRYKER=true stryker run"
+    "stryker": "cross-env STRYKER=true stryker run",
+    "get-version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",

--- a/packages/mutation-testing-metrics-scala/build.sbt
+++ b/packages/mutation-testing-metrics-scala/build.sbt
@@ -34,6 +34,7 @@ lazy val elements = project
   .in(file("mutation-testing-elements"))
   .settings(
     npmProjectSettings,
+    version := packageVersion(file("../mutation-testing-elements")),
     name := "mutation-testing-elements",
     description := "A suite of web components for a mutation testing report.",
     skip in publish := skipElementsPublish
@@ -43,18 +44,20 @@ lazy val schema = project
   .in(file("mutation-testing-report-schema"))
   .settings(
     npmProjectSettings,
+    version := packageVersion(file("../mutation-testing-report-schema")),
     name := "mutation-testing-report-schema",
     description := "The json schema for a mutation testing report.",
     skip in publish := skipSchemaPublish
   )
 
 lazy val sharedSettings = Seq(
-  libraryDependencies += "org.scalameta" %% "munit" % "0.7.11" % Test,
+  libraryDependencies += "org.scalameta" %% "munit" % "0.7.14" % Test,
   testFrameworks := List(new TestFramework("munit.Framework")),
   scalaVersion := Scala213,
   crossScalaVersions := Seq(Scala213, Scala212),
   skip in publish := skipNormalProjectPublish,
-  publishTo := sonatypePublishToBundle.value
+  publishTo := sonatypePublishToBundle.value,
+  version := packageVersion(file("."))
 )
 
 lazy val npmProjectSettings = Seq(
@@ -83,3 +86,15 @@ lazy val skipSchemaPublish = !envVarIsTrue("PUBLISH_SCHEMA")
 // Default, publish except if PUBLISH_ELEMENTS or PUBLISH_SCHEMA is true
 // See NPM_PROJECTS_PUBLISHING.md for more info
 lazy val skipNormalProjectPublish = !skipElementsPublish || !skipSchemaPublish
+
+def packageVersion(packageJsonDir: File): String = {
+  import scala.sys.process._
+
+  val command = Seq("npm", "run", "get-version")
+  val os      = sys.props("os.name").toLowerCase
+  val panderToWindows = os match {
+    case n if n contains "windows" => Seq("cmd", "/C") ++ command
+    case _                         => command
+  }
+  Process(panderToWindows, packageJsonDir).!!.linesIterator.toIterable.last
+}

--- a/packages/mutation-testing-metrics-scala/project/build.properties
+++ b/packages/mutation-testing-metrics-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.1

--- a/packages/mutation-testing-metrics-scala/sonatype.sbt
+++ b/packages/mutation-testing-metrics-scala/sonatype.sbt
@@ -2,17 +2,6 @@ inThisBuild(
   Seq(
     // Don't publish root project
     skip in publish := true,
-    version := {
-      import scala.sys.process._
-
-      val command = Seq("npm", "run", "get-version")
-      val os      = sys.props("os.name").toLowerCase
-      val panderToWindows = os match {
-        case n if n contains "windows" => Seq("cmd", "/C") ++ command
-        case _                         => command
-      }
-      panderToWindows.!!.linesIterator.toIterable.last
-    },
     publishMavenStyle := true,
     organization := "io.stryker-mutator",
     homepage := Some(url("https://stryker-mutator.io/")),

--- a/packages/mutation-testing-report-schema/package.json
+++ b/packages/mutation-testing-report-schema/package.json
@@ -6,7 +6,8 @@
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha --forbid-only --forbid-pending -r source-map-support/register dist/test/**/*.js",
-    "postpublish": "PUBLISH_SCHEMA=true ../mutation-testing-metrics-scala/npmProjPublish.sh dist/src"
+    "postpublish": "PUBLISH_SCHEMA=true ../mutation-testing-metrics-scala/npmProjPublish.sh dist/src",
+    "get-version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Before:

```
❯ sbtn version          
> version
[info] schema / version
[info]  1.4.0
[info] elements / version
[info]  1.4.0
[info] metrics / version
[info]  1.4.0
[info] circe / version
[info]  1.4.0
```

After:
```
❯ sbtn version          
> version
[info] schema / version
[info]  1.4.1
[info] elements / version
[info]  1.4.1
[info] metrics / version
[info]  1.4.0
[info] circe / version
[info]  1.4.0
```