### PR TITLE
feat(metrics-scala): align naming of types with schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 _site/
 .metals/
 .bloop/
+.bsp/
 .idea/
 pom.xml.versionsBackup
 packages/*/mvn/resources/

--- a/packages/mutation-testing-metrics-scala/.vscode/settings.json
+++ b/packages/mutation-testing-metrics-scala/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/packages/mutation-testing-metrics-scala/README.md
+++ b/packages/mutation-testing-metrics-scala/README.md
@@ -23,9 +23,9 @@ First create the mutation test report:
 
 ```scala
 import mutationtesting._
-val report = MutationTestReport(thresholds = Thresholds(high = 80, low = 10),
+val report = MutationTestResult(thresholds = Thresholds(high = 80, low = 10),
   files = Map(
-    "src/stryker4s/Stryker4s.scala" -> MutationTestResult(
+    "src/stryker4s/Stryker4s.scala" -> FileResult(
       source = "case class Stryker4s(foo: String)",
       mutants = Seq(
         MutantResult("1", "BinaryOperator", "-", Location(Position(1, 2), Position(2, 3)), status = MutantStatus.Killed)
@@ -35,7 +35,7 @@ val report = MutationTestReport(thresholds = Thresholds(high = 80, low = 10),
 )
 ```
 
-The `MutationTestReport` case classes generate a JSON compliant with the [mutation-testing JSON schema](https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json).
+The `MutationTestResult` case classes generate a JSON compliant with the [mutation-testing JSON schema](https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json).
 
 
 Then calculate and use metrics from that report:
@@ -82,7 +82,7 @@ Import the decoder:
 import io.circe.parser.decode
 import mutationtesting.MutationReportDecoder._
 
-val decoded: Either[io.circe.Error, MutationTestReport] = decode[MutationTestReport](json)
+val decoded: Either[io.circe.Error, MutationTestResult] = decode[MutationTestResult](json)
 ```
 
 ## API reference

--- a/packages/mutation-testing-metrics-scala/build.sbt
+++ b/packages/mutation-testing-metrics-scala/build.sbt
@@ -1,5 +1,5 @@
 val Scala212 = "2.12.11"
-val Scala213 = "2.13.3"
+val Scala213 = "2.13.4"
 
 scalaVersion := Scala213
 
@@ -51,7 +51,7 @@ lazy val schema = project
   )
 
 lazy val sharedSettings = Seq(
-  libraryDependencies += "org.scalameta" %% "munit" % "0.7.15" % Test,
+  libraryDependencies += "org.scalameta" %% "munit" % "0.7.20" % Test,
   testFrameworks := List(new TestFramework("munit.Framework")),
   scalaVersion := Scala213,
   crossScalaVersions := Seq(Scala213, Scala212),

--- a/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/MutationReportDecoder.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/MutationReportDecoder.scala
@@ -16,9 +16,9 @@ object MutationReportDecoder {
   implicit val mutantResultDecoder: Decoder[MutantResult] =
     Decoder.forProduct6("id", "mutatorName", "replacement", "location", "status", "description")(MutantResult.apply)
 
-  implicit val mutationTestResultDecoder: Decoder[MutationTestResult] =
-    Decoder.forProduct3("source", "mutants", "language")(MutationTestResult.apply)
+  implicit val fileResultDecoder: Decoder[FileResult] =
+    Decoder.forProduct3("source", "mutants", "language")(FileResult.apply)
 
-  implicit val mutationTestReportDecoder: Decoder[MutationTestReport] =
-    Decoder.forProduct5("$schema", "schemaVersion", "thresholds", "projectRoot", "files")(MutationTestReport.apply)
+  implicit val mutationTestResultDecoder: Decoder[MutationTestResult] =
+    Decoder.forProduct5("$schema", "schemaVersion", "thresholds", "projectRoot", "files")(MutationTestResult.apply)
 }

--- a/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/MutationReportEncoder.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/MutationReportEncoder.scala
@@ -19,12 +19,12 @@ object MutationReportEncoder {
         (m.id, m.mutatorName, m.replacement, m.location, m.status, m.description)
       )
 
-  implicit val mutationTestResultEncoder: Encoder[MutationTestResult] =
+  implicit val fileResultEncoder: Encoder[FileResult] =
     Encoder.forProduct3("source", "mutants", "language")(m => (m.source, m.mutants, m.language))
 
-  implicit val mutationTestReportEncoder: Encoder[MutationTestReport] =
+  implicit val mutationTestResultEncoder: Encoder[MutationTestResult] =
     Encoder
-      .forProduct5("$schema", "schemaVersion", "thresholds", "projectRoot", "files")((m: MutationTestReport) =>
+      .forProduct5("$schema", "schemaVersion", "thresholds", "projectRoot", "files")((m: MutationTestResult) =>
         (m.`$schema`, m.schemaVersion, m.thresholds, m.projectRoot, m.files)
       )
       .mapJson(_.deepDropNullValues)

--- a/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/EncoderTest.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/EncoderTest.scala
@@ -25,10 +25,10 @@ class EncoderTest extends munit.FunSuite {
   }
 
   def testReport =
-    MutationTestReport(
+    MutationTestResult(
       thresholds = Thresholds(high = 80, low = 10),
       files = Map(
-        "src/stryker4s/Stryker4s.scala" -> MutationTestResult(
+        "src/stryker4s/Stryker4s.scala" -> FileResult(
           source = "case class Stryker4s(foo: String)",
           mutants = Seq(
             MutantResult(

--- a/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/SchemaTest.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/test/scala/mutationtesting/SchemaTest.scala
@@ -9,10 +9,10 @@ import scala.io.Source
 class SchemaTest extends munit.FunSuite {
 
   test("encoded json should be valid for mutation-testing-report-schema") {
-    val sut = MutationTestReport(
+    val sut = MutationTestResult(
       thresholds = Thresholds(high = 80, low = 10),
       files = Map(
-        "src/stryker4s/Stryker4s.scala" -> MutationTestResult(
+        "src/stryker4s/Stryker4s.scala" -> FileResult(
           source = "case class Stryker4s(foo: String)",
           mutants = Seq(
             MutantResult(
@@ -41,7 +41,7 @@ class SchemaTest extends munit.FunSuite {
     val report =
       Source.fromFile("../mutation-testing-elements/testResources/scala-example/mutation-report.json").mkString
 
-    decode[MutationTestReport](report) match {
+    decode[MutationTestResult](report) match {
       case Left(err) => fail(err.getMessage())
       case Right(report) =>
         assert(report.`$schema`.isEmpty)
@@ -56,7 +56,7 @@ class SchemaTest extends munit.FunSuite {
     }
   }
 
-  def toJsonString(report: MutationTestReport) = {
+  def toJsonString(report: MutationTestResult) = {
     import mutationtesting.MutationReportEncoder._
     import io.circe.syntax._
     report.asJson.noSpaces

--- a/packages/mutation-testing-metrics-scala/docs/README.md
+++ b/packages/mutation-testing-metrics-scala/docs/README.md
@@ -23,9 +23,9 @@ First create the mutation test report:
 
 ```scala mdoc:silent
 import mutationtesting._
-val report = MutationTestReport(thresholds = Thresholds(high = 80, low = 10),
+val report = MutationTestResult(thresholds = Thresholds(high = 80, low = 10),
   files = Map(
-    "src/stryker4s/Stryker4s.scala" -> MutationTestResult(
+    "src/stryker4s/Stryker4s.scala" -> FileResult(
       source = "case class Stryker4s(foo: String)",
       mutants = Seq(
         MutantResult("1", "BinaryOperator", "-", Location(Position(1, 2), Position(2, 3)), status = MutantStatus.Killed)
@@ -35,7 +35,7 @@ val report = MutationTestReport(thresholds = Thresholds(high = 80, low = 10),
 )
 ```
 
-The `MutationTestReport` case classes generate a JSON compliant with the [mutation-testing JSON schema](https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json).
+The `MutationTestResult` case classes generate a JSON compliant with the [mutation-testing JSON schema](https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json).
 
 ```scala mdoc:reset:invisible
 // Read actual json for more interesting metrics
@@ -45,7 +45,7 @@ import mutationtesting._
 import mutationtesting.MutationReportDecoder._
 val json = Source.fromFile("../mutation-testing-elements/testResources/scala-example/mutation-report.json").mkString
 
-val report = decode[MutationTestReport](json) match {
+val report = decode[MutationTestResult](json) match {
   case Left(err)  => throw err
   case Right(rep) => rep
 }
@@ -92,7 +92,7 @@ Import the decoder:
 import io.circe.parser.decode
 import mutationtesting.MutationReportDecoder._
 
-val decoded: Either[io.circe.Error, MutationTestReport] = decode[MutationTestReport](json)
+val decoded: Either[io.circe.Error, MutationTestResult] = decode[MutationTestResult](json)
 ```
 
 ## API reference

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/Metrics.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/Metrics.scala
@@ -2,18 +2,18 @@ package mutationtesting
 
 object Metrics {
 
-  def calculateMetrics(mutationTestReport: MutationTestReport): MetricsResult =
+  def calculateMetrics(mutationTestReport: MutationTestResult): MetricsResult =
     calculateMetrics(mutationTestReport.files)
 
-  def calculateMetrics(mutationTestResults: Map[String, MutationTestResult]): MetricsResult =
+  def calculateMetrics(mutationTestResults: FileResultDictionary): MetricsResult =
     MetricsResultRoot(
       parseMutationTestResults(
         mutationTestResults
-          .map({ case (name, result) => (name.split("/").toIterable, result) })
+          .map({ case (name, result) => (name.split("/").toSeq, result) })
       )
     )
 
-  private def parseMutationTestResults(results: Map[Iterable[String], MutationTestResult]): Iterable[MetricsResult] = {
+  private def parseMutationTestResults(results: Map[Seq[String], FileResult]): Seq[MetricsResult] = {
     val (rootFiles, directories) = results.partition(_._1.size == 1)
 
     directories

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
@@ -2,18 +2,41 @@ package mutationtesting
 
 import mutationtesting.MutantStatus._
 
-final case class MutationTestReport(
+/** Schema for a mutation testing report
+  *
+  * @param `$schema` URL to the JSON schema.
+  * @param schemaVersion Major version of this report. Used for compatibility.
+  * @param thresholds Thresholds for the status of the reported application.
+  * @param projectRoot The optional location of the project root.
+  * @param files All mutated files.
+  */
+final case class MutationTestResult(
     `$schema`: Option[String] = Some(
       "https://git.io/mutation-testing-report-schema"
     ),
     schemaVersion: String = "1",
     thresholds: Thresholds,
     projectRoot: Option[String] = None,
-    files: Map[String, MutationTestResult]
+    files: FileResultDictionary
 )
 
-final case class MutationTestResult(source: String, mutants: Seq[MutantResult], language: String = "scala")
+/** Mutated file
+  *
+  * @param source Full source code of the mutated file, this is used for highlighting.
+  * @param mutants All mutants in this file.
+  * @param language Programming language that is used. Used for code highlighting, see https://prismjs.com/#examples.
+  */
+final case class FileResult(source: String, mutants: Seq[MutantResult], language: String = "scala")
 
+/** Single mutation.
+  *
+  * @param id Unique id, can be used to correlate this mutant with other reports.
+  * @param mutatorName Category of the mutation.
+  * @param replacement Actual mutation that has been applied.
+  * @param location A location with start and end. Start is inclusive, end is exclusive.
+  * @param status Result of the mutation.
+  * @param description Description of the applied mutation.
+  */
 final case class MutantResult(
     id: String,
     mutatorName: String,
@@ -23,8 +46,20 @@ final case class MutantResult(
     description: Option[String] = None
 )
 
+/** A location with start and end. Start is inclusive, end is exclusive.
+  *
+  * @param start Starting location (inclusive).
+  * @param end End location (exclusive).
+  */
 final case class Location(start: Position, end: Position)
 
+/** Position of a mutation. Both line and column start at one.
+  */
 final case class Position(line: Int, column: Int)
 
+/** Thresholds for the status of the reported application.
+  *
+  * @param high Higher bound threshold.
+  * @param low Lower bound threshold.
+  */
 final case class Thresholds(high: Int, low: Int)

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/package.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/package.scala
@@ -1,0 +1,7 @@
+package object mutationtesting {
+
+  /** All mutated files, with the relative path of the file as the key
+    */
+  type FileResultDictionary = Map[String, FileResult]
+
+}

--- a/packages/mutation-testing-metrics-scala/metrics/src/test/scala/mutationtesting/MetricsTest.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/test/scala/mutationtesting/MetricsTest.scala
@@ -3,11 +3,11 @@ package mutationtesting
 import mutationtesting.MutantStatus._
 
 class MetricsTest extends munit.FunSuite {
-  test("MutationTestResult is split into tree structure") {
-    val mtr = Map(
-      "dir/foo.scala" -> MutationTestResult("dirFoo", Nil),
-      "dir/bar.scala" -> MutationTestResult("dirBar", Nil),
-      "foo.scala"     -> MutationTestResult("foo", Nil)
+  test("FileResultDictionary is split into tree structure") {
+    val mtr: FileResultDictionary = Map(
+      "dir/foo.scala" -> FileResult("dirFoo", Nil),
+      "dir/bar.scala" -> FileResult("dirBar", Nil),
+      "foo.scala"     -> FileResult("foo", Nil)
     )
     val result = Metrics.calculateMetrics(mtr)
     assertEquals(
@@ -21,7 +21,7 @@ class MetricsTest extends munit.FunSuite {
     )
   }
 
-  test("MutationTestResult split into more complex tree structure") {
+  test("FileResultDictionary split into more complex tree structure") {
     val iter = Iterator.from(0)
     def rndMutation: MutantResult = {
       val id     = iter.next()
@@ -36,13 +36,13 @@ class MetricsTest extends munit.FunSuite {
     }
     def rndMutants(count: Int) = Seq.fill(count)(rndMutation)
 
-    val mtr = Map(
-      "foo.scala"             -> MutationTestResult("foo", rndMutants(0)),
-      "dir/foo/bar.scala"     -> MutationTestResult("dirFoo", rndMutants(1)),
-      "foo/foo/foo/bar.scala" -> MutationTestResult("dirFoo", rndMutants(2)),
-      "dir/bar/foo.scala"     -> MutationTestResult("dirFoo", rndMutants(2)),
-      "dir/baz/bar.scala"     -> MutationTestResult("dirBar", rndMutants(1)),
-      "dir/baz.scala"         -> MutationTestResult("dirBar", rndMutants(0))
+    val mtr: FileResultDictionary = Map(
+      "foo.scala"             -> FileResult("foo", rndMutants(0)),
+      "dir/foo/bar.scala"     -> FileResult("dirFoo", rndMutants(1)),
+      "foo/foo/foo/bar.scala" -> FileResult("dirFoo", rndMutants(2)),
+      "dir/bar/foo.scala"     -> FileResult("dirFoo", rndMutants(2)),
+      "dir/baz/bar.scala"     -> FileResult("dirBar", rndMutants(1)),
+      "dir/baz.scala"         -> FileResult("dirBar", rndMutants(0))
     )
     val result = Metrics.calculateMetrics(mtr)
     assertEquals(

--- a/packages/mutation-testing-metrics-scala/metrics/src/test/scala/mutationtesting/MutationTestResultTest.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/test/scala/mutationtesting/MutationTestResultTest.scala
@@ -1,15 +1,15 @@
 package mutationtesting
 
 class MutationTestResultTest extends munit.FunSuite {
-  test("MutationTestReport should have correct default $schema and schemaVersion") {
-    val sut = MutationTestReport(thresholds = Thresholds(80, 60), files = Map.empty)
+  test("MutationTestResult should have correct default $schema and schemaVersion") {
+    val sut = MutationTestResult(thresholds = Thresholds(80, 60), files = Map.empty)
 
     assertEquals(sut.`$schema`.get, "https://git.io/mutation-testing-report-schema")
     assertEquals(sut.schemaVersion, "1")
   }
 
-  test("MutationTestResult should have default language Scala") {
-    val sut = MutationTestResult("", Seq.empty)
+  test("FileResult should have default language Scala") {
+    val sut = FileResult("", Seq.empty)
 
     assertEquals(sut.language, "scala")
   }

--- a/packages/mutation-testing-metrics-scala/package.json
+++ b/packages/mutation-testing-metrics-scala/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.4",
   "description": "Zero-dependency library to calculate mutation testing metrics in Scala.",
   "scripts": {
-    "test": "sbt \"+compile; test\"",
+    "test": "sbt \"+compile; test; docs/mdoc --check\"",
     "prepublishOnly": "sbt +publishSigned",
     "publish": "sbt sonatypeBundleRelease",
     "get-version": "echo $npm_package_version",

--- a/packages/mutation-testing-metrics-scala/project/build.properties
+++ b/packages/mutation-testing-metrics-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.4.5

--- a/packages/mutation-testing-metrics-scala/project/plugins.sbt
+++ b/packages/mutation-testing-metrics-scala/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
-addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.0.1")
+addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.1.1")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.10")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.14")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.14")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
 
-addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.10.0-RC3")
+addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.10.0")


### PR DESCRIPTION
Also add ScalaDoc comments from schema

BREAKING CHANGE: MutationTestReport was renamed to MutationTestResult
BREAKING CHANGE: MutationTestResult was renamed to FileResult
