### PR TITLE
feat(schema): add test file source and status reason

### DIFF
--- a/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/circe.scala
+++ b/packages/mutation-testing-metrics-scala/circe/src/main/scala/mutationtesting/circe.scala
@@ -38,12 +38,13 @@ object circe {
     Codec.forProduct3("source", "mutants", "language")(FileResult.apply)(f => (f.source, f.mutants, f.language))
 
   implicit lazy val mutantResultCodec: Codec[MutantResult] =
-    Codec.forProduct10(
+    Codec.forProduct11(
       "id",
       "mutatorName",
       "replacement",
       "location",
       "status",
+      "statusReason",
       "description",
       "coveredBy",
       "killedBy",
@@ -56,6 +57,7 @@ object circe {
         m.replacement,
         m.location,
         m.status,
+        m.statusReason,
         m.description,
         m.coveredBy,
         m.killedBy,
@@ -68,7 +70,7 @@ object circe {
     .forProduct2("high", "low")(Thresholds.apply)(t => (t.high, t.low))
     .mapDecoder(_.emap(t => Thresholds.create(high = t.high, low = t.low)))
 
-  implicit lazy val testFileCodec: Codec[TestFile] = Codec.forProduct1("tests")(TestFile.apply)(t => t.tests)
+  implicit lazy val testFileCodec: Codec[TestFile] = Codec.forProduct2("tests", "source")(TestFile.apply)(t => (t.tests, t.source))
 
   implicit lazy val mutantStatusCodec: Codec[MutantStatus] =
     Codec

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
@@ -35,8 +35,10 @@ final case class MutationTestResult(
 final case class FileResult(source: String, mutants: Seq[MutantResult], language: String = "scala")
 
 /** A file containing one or more tests
+  * @param source Full source code of the test file. This can be used to display in the report.
+  * @param tests The tests contained in this test file.
   */
-final case class TestFile(source: Option[String], tests: Seq[TestDefinition])
+final case class TestFile(tests: Seq[TestDefinition], source: Option[String] = None)
 
 /** A test in your test file.
   *
@@ -53,7 +55,7 @@ final case class TestDefinition(id: String name: String, location: Option[OpenEn
   * @param replacement Actual mutation that has been applied.
   * @param location A location with start and end. Start is inclusive, end is exclusive.
   * @param status Result of the mutation.
-  * @param statusReason The reason that this mutant has this status. In case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of a error mutant, this should be filled with the error message.
+  * @param statusReason The reason that this mutant has this status. In the case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of an error mutant, this should be filled with the error message.
   * @param description Description of the applied mutation.
   * @param coveredBy The test ids that covered this mutant. If a mutation testing framework doesn't measure this information, it can simply be left out.
   * @param killedBy The test ids that killed this mutant. It is a best practice to "bail" on first failing test, in which case you can fill this array with that one test.

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
@@ -36,7 +36,7 @@ final case class FileResult(source: String, mutants: Seq[MutantResult], language
 
 /** A file containing one or more tests
   */
-final case class TestFile(tests: Seq[TestDefinition])
+final case class TestFile(source: Option[String], tests: Seq[TestDefinition])
 
 /** A test in your test file.
   *
@@ -44,7 +44,7 @@ final case class TestFile(tests: Seq[TestDefinition])
   * @param name Name of the test, used to display the test.
   * @param location A [[mutationtesting.Location]] where `end` is not required
   */
-final case class TestDefinition(id: String, name: String, location: Option[OpenEndLocation])
+final case class TestDefinition(id: String name: String, location: Option[OpenEndLocation])
 
 /** Single mutation.
   *
@@ -53,6 +53,7 @@ final case class TestDefinition(id: String, name: String, location: Option[OpenE
   * @param replacement Actual mutation that has been applied.
   * @param location A location with start and end. Start is inclusive, end is exclusive.
   * @param status Result of the mutation.
+  * @param statusReason The reason that this mutant has this status. In case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of a error mutant, this should be filled with the error message.
   * @param description Description of the applied mutation.
   * @param coveredBy The test ids that covered this mutant. If a mutation testing framework doesn't measure this information, it can simply be left out.
   * @param killedBy The test ids that killed this mutant. It is a best practice to "bail" on first failing test, in which case you can fill this array with that one test.
@@ -65,6 +66,7 @@ final case class MutantResult(
     replacement: String,
     location: Location,
     status: MutantStatus,
+    statusReason: Option[String] = None,
     description: Option[String] = None,
     coveredBy: Option[Seq[String]] = None,
     killedBy: Option[Seq[String]] = None,

--- a/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
+++ b/packages/mutation-testing-metrics-scala/metrics/src/main/scala/mutationtesting/mutationTestResult.scala
@@ -46,7 +46,7 @@ final case class TestFile(tests: Seq[TestDefinition], source: Option[String] = N
   * @param name Name of the test, used to display the test.
   * @param location A [[mutationtesting.Location]] where `end` is not required
   */
-final case class TestDefinition(id: String name: String, location: Option[OpenEndLocation])
+final case class TestDefinition(id: String, name: String, location: Option[OpenEndLocation])
 
 /** Single mutation.
   *

--- a/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
+++ b/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
@@ -91,6 +91,10 @@
                   "description": "Result of the mutation.",
                   "enum": ["Killed", "Survived", "NoCoverage", "CompileError", "RuntimeError", "Timeout", "Ignored"]
                 },
+                "statusReason": {
+                  "type": "string",
+                  "description": "The reason that this mutant has this status. In case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of a error mutant, this should be filled with the error message."
+                },
                 "testsCompleted": {
                   "type": "number",
                   "description": "The number of tests actually completed in order to test this mutant. Can differ from \"coveredBy\" because of bailing a mutant test run after first failing test."
@@ -99,7 +103,7 @@
             }
           },
           "source": {
-            "description": "Full source code of the mutated file, this is used for highlighting.",
+            "description": "Full source code of the original file (without mutants), this is used to display exactly what was changed for each mutant.",
             "examples": ["using System; using....."],
             "type": "string"
           }
@@ -116,6 +120,10 @@
         "description": "A file containing one or more tests",
         "required": ["tests"],
         "properties": {
+          "source": {
+            "description": "Full source code of the test file, this can be used to display in the report.",
+            "type": "string"
+          },
           "tests": {
             "type": "array",
             "items": {

--- a/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
+++ b/packages/mutation-testing-report-schema/src/mutation-testing-report-schema.json
@@ -93,7 +93,7 @@
                 },
                 "statusReason": {
                   "type": "string",
-                  "description": "The reason that this mutant has this status. In case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of a error mutant, this should be filled with the error message."
+                  "description": "The reason that this mutant has this status. In the case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of an error mutant, this should be filled with the error message."
                 },
                 "testsCompleted": {
                   "type": "number",

--- a/packages/mutation-testing-report-schema/test/unit/TypeScript.spec.ts
+++ b/packages/mutation-testing-report-schema/test/unit/TypeScript.spec.ts
@@ -39,6 +39,7 @@ const mutantResult: MutantResult = {
   status: mutantStatus,
   description: 'changed foo in bar',
   replacement: 'bar',
+  statusReason: 'Expected "foo" to be "bar"',
 
   // @ts-expect-error check to see if the index signature is missing
   alive: false,
@@ -138,6 +139,7 @@ const test: TestDefinition = {
 
 const testFiles: TestFileDefinitionDictionary = {
   'test/foo.spec.js': {
+    source: 'describe("foo", () => {})',
     tests: [test],
   },
 };

--- a/packages/mutation-testing-report-schema/testResources/strict-report.json
+++ b/packages/mutation-testing-report-schema/testResources/strict-report.json
@@ -60,6 +60,7 @@
             }
           },
           "status": "Killed",
+          "statusReason": "Expected 'foo' to be 'bar'",
           "coveredBy": ["test-1", "test-2", "test-3"],
           "killedBy": ["test-2"],
           "duration": 4,
@@ -93,6 +94,7 @@
   "projectRoot": "/home/user/projects/project-under-test",
   "testFiles": {
     "test/foo.spec.js": {
+      "source": "describe('add', () => {})",
       "tests": [
         {
           "id": "test-1",


### PR DESCRIPTION
Add `statusReason` to a mutant result and `source` to a test file.

Status reason:
The reason that this mutant has this status. In the case of a killed mutant, this should be filled with the failure message(s) of the failing tests. In case of an error mutant, this should be filled with the error message.

Closes #891 

Source:
Full source code of the test file. This can be used to display in the report.

Closes #892 