### PR TITLE
feat(file): add methods to retrieve source content

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,9 @@
   "command": {
     "version": {
       "allowBranch": "master"
+    },
+    "publish": {
+      "preDistTag": "beta"
     }
   }
 }

--- a/packages/mutation-testing-elements/test/unit/components/mutation-test-report-totals.spec.ts
+++ b/packages/mutation-testing-elements/test/unit/components/mutation-test-report-totals.spec.ts
@@ -22,7 +22,7 @@ describe(MutationTestReportTotalsComponent.name, () => {
 
   it('should show a table with a single row for a file result', async () => {
     sut.element.model = createMetricsResult({
-      file: new FileUnderTestModel(createFileResult()),
+      file: new FileUnderTestModel(createFileResult(), ''),
     });
     await sut.whenStable();
     const table = sut.$('table') as HTMLTableElement;
@@ -34,7 +34,7 @@ describe(MutationTestReportTotalsComponent.name, () => {
   it('should show a table with a 3 rows for a directory result with 2 directories and one file', async () => {
     const file = createMetricsResult({
       name: 'foo.js',
-      file: new FileUnderTestModel(createFileResult()),
+      file: new FileUnderTestModel(createFileResult(), ''),
     });
     sut.element.model = createMetricsResult({
       name: 'bar',
@@ -50,7 +50,7 @@ describe(MutationTestReportTotalsComponent.name, () => {
     // Arrange
     const file = createMetricsResult({
       name: 'foo.js',
-      file: new FileUnderTestModel(createFileResult()),
+      file: new FileUnderTestModel(createFileResult(), ''),
     });
     sut.element.model = createMetricsResult({
       name: 'bar',

--- a/packages/mutation-testing-metrics/src/calculateMetrics.ts
+++ b/packages/mutation-testing-metrics/src/calculateMetrics.ts
@@ -12,7 +12,7 @@ const ROOT_NAME_TESTS = 'All tests';
  * @returns A MetricsResult containing the metrics for the entire report. See `childResults`
  */
 export function calculateMetrics(files: Record<string, FileResult>): MetricsResult<FileUnderTestModel, Metrics> {
-  const normalizedFiles = normalize(files, (input) => new FileUnderTestModel(input));
+  const normalizedFiles = normalize(files, (input, name) => new FileUnderTestModel(input, name));
   return calculateDirectoryMetrics(ROOT_NAME, normalizedFiles, countFileMetrics);
 }
 
@@ -23,9 +23,9 @@ export function calculateMetrics(files: Record<string, FileResult>): MetricsResu
  */
 export function calculateMutationTestMetrics(result: MutationTestResult): MutationTestMetricsResult {
   const { files, testFiles } = result;
-  const fileModelsUnderTest = normalize(files, (input) => new FileUnderTestModel(input));
+  const fileModelsUnderTest = normalize(files, (input, name) => new FileUnderTestModel(input, name));
   if (testFiles) {
-    const testFileModels = normalize(testFiles, (input) => new TestFileModel(input));
+    const testFileModels = normalize(testFiles, (input, name) => new TestFileModel(input, name));
     relate(
       Object.values(fileModelsUnderTest).flatMap((file) => file.mutants),
       Object.values(testFileModels).flatMap((file) => file.tests)

--- a/packages/mutation-testing-metrics/src/helpers/file.ts
+++ b/packages/mutation-testing-metrics/src/helpers/file.ts
@@ -5,12 +5,12 @@ export function normalizeFileNames<TIn>(input: Record<string, TIn>): Record<stri
   return normalize(input, (input) => input);
 }
 
-export function normalize<TIn, TOut>(input: Record<string, TIn>, factory: (input: TIn) => TOut): Record<string, TOut> {
+export function normalize<TIn, TOut>(input: Record<string, TIn>, factory: (input: TIn, fileName: string) => TOut): Record<string, TOut> {
   const fileNames = Object.keys(input);
   const commonBasePath = determineCommonBasePath(fileNames);
   const output: Record<string, TOut> = Object.create(null);
   fileNames.forEach((fileName) => {
-    output[normalizeName(fileName.substr(commonBasePath.length))] = factory(input[fileName]);
+    output[normalizeName(fileName.substr(commonBasePath.length))] = factory(input[fileName], fileName);
   });
   return output;
 }

--- a/packages/mutation-testing-metrics/src/helpers/file.ts
+++ b/packages/mutation-testing-metrics/src/helpers/file.ts
@@ -1,16 +1,5 @@
-import { MetricsResult } from './model/metrics-result';
+import { MetricsResult } from '../model/metrics-result';
 const SEPARATOR = '/';
-
-export function groupBy<T>(arr: T[], criteria: (element: T) => string): Record<string, T[]> {
-  return arr.reduce((acc: Record<string, T[]>, item) => {
-    const key = criteria(item);
-    if (!Object.prototype.hasOwnProperty.call(acc, key)) {
-      acc[key] = [];
-    }
-    acc[key].push(item);
-    return acc;
-  }, {});
-}
 
 export function normalizeFileNames<TIn>(input: Record<string, TIn>): Record<string, TIn> {
   return normalize(input, (input) => input);

--- a/packages/mutation-testing-metrics/src/helpers/group-by.ts
+++ b/packages/mutation-testing-metrics/src/helpers/group-by.ts
@@ -1,0 +1,10 @@
+export function groupBy<T>(arr: T[], criteria: (element: T) => string): Record<string, T[]> {
+  return arr.reduce((acc: Record<string, T[]>, item) => {
+    const key = criteria(item);
+    if (!Object.prototype.hasOwnProperty.call(acc, key)) {
+      acc[key] = [];
+    }
+    acc[key].push(item);
+    return acc;
+  }, {});
+}

--- a/packages/mutation-testing-metrics/src/helpers/index.ts
+++ b/packages/mutation-testing-metrics/src/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from './group-by';
+export * from './file';
+export * from './text';

--- a/packages/mutation-testing-metrics/src/helpers/text.ts
+++ b/packages/mutation-testing-metrics/src/helpers/text.ts
@@ -48,7 +48,6 @@ export function computeLineStarts(text: string): number[] {
         }
         progressLineStart(pos);
         break;
-      // falls through
       case CharacterCodes.lineFeed:
         progressLineStart(pos);
         break;

--- a/packages/mutation-testing-metrics/src/helpers/text.ts
+++ b/packages/mutation-testing-metrics/src/helpers/text.ts
@@ -1,0 +1,64 @@
+// The implementation of this file is grabbed and modified from TypeScript source code
+
+const enum CharacterCodes {
+  maxAsciiCharacter = 0x7f,
+  lineFeed = 0x0a, // \n
+  carriageReturn = 0x0d, // \r
+  lineSeparator = 0x2028,
+  paragraphSeparator = 0x2029,
+}
+
+function isLineBreak(ch: number): boolean {
+  // ES5 7.3:
+  // The ECMAScript line terminator characters are listed in Table 3.
+  //     Table 3: Line Terminator Characters
+  //     Code Unit Value     Name                    Formal Name
+  //     \u000A              Line Feed               <LF>
+  //     \u000D              Carriage Return         <CR>
+  //     \u2028              Line separator          <LS>
+  //     \u2029              Paragraph separator     <PS>
+  // Only the characters in Table 3 are treated as line terminators. Other new line or line
+  // breaking characters are treated as white space but not as line terminators.
+
+  return (
+    ch === CharacterCodes.lineFeed ||
+    ch === CharacterCodes.carriageReturn ||
+    ch === CharacterCodes.lineSeparator ||
+    ch === CharacterCodes.paragraphSeparator
+  );
+}
+
+export function computeLineStarts(text: string): number[] {
+  const result: number[] = [];
+  let pos = 0;
+  let lineStart = 0;
+  function progressLineStart(pos: number) {
+    result.push(lineStart);
+    lineStart = pos;
+  }
+  // Mutation testing elements works with 1-based lines
+  progressLineStart(0);
+  while (pos < text.length) {
+    const ch = text.charCodeAt(pos);
+    pos++;
+    switch (ch) {
+      case CharacterCodes.carriageReturn:
+        if (text.charCodeAt(pos) === CharacterCodes.lineFeed) {
+          pos++;
+        }
+        progressLineStart(pos);
+        break;
+      // falls through
+      case CharacterCodes.lineFeed:
+        progressLineStart(pos);
+        break;
+      default:
+        if (ch > CharacterCodes.maxAsciiCharacter && isLineBreak(ch)) {
+          progressLineStart(pos);
+        }
+        break;
+    }
+  }
+  result.push(lineStart);
+  return result;
+}

--- a/packages/mutation-testing-metrics/src/index.ts
+++ b/packages/mutation-testing-metrics/src/index.ts
@@ -1,3 +1,3 @@
 export { calculateMetrics, calculateMutationTestMetrics } from './calculateMetrics';
 export { normalizeFileNames } from './helpers';
-export { MetricsResult, Metrics, TestMetrics, TestModel, FileUnderTestModel, TestFileModel, MutantModel } from './model';
+export { MetricsResult, Metrics, TestMetrics, TestModel, FileUnderTestModel, TestFileModel, MutantModel, MutationTestMetricsResult } from './model';

--- a/packages/mutation-testing-metrics/src/model/file-under-test-model.ts
+++ b/packages/mutation-testing-metrics/src/model/file-under-test-model.ts
@@ -1,10 +1,11 @@
-import { FileResult } from 'mutation-testing-report-schema';
+import { FileResult, MutantResult } from 'mutation-testing-report-schema';
 import { MutantModel } from './mutant-model';
+import { assertSourceDefined, SourceFile } from './source-file';
 
 /**
  * Represents a file which was mutated (your production code).
  */
-export class FileUnderTestModel implements FileResult {
+export class FileUnderTestModel extends SourceFile implements FileResult {
   /**
    * Programming language that is used. Used for code highlighting, see https://prismjs.com/#examples.
    */
@@ -19,10 +20,26 @@ export class FileUnderTestModel implements FileResult {
   mutants: MutantModel[];
 
   constructor(input: FileResult) {
+    super();
     Object.entries(input).forEach(([key, value]) => {
       // @ts-expect-error dynamic assignment so we won't forget to add new properties
       this[key] = value;
     });
-    this.mutants = input.mutants.map((mutant) => new MutantModel(mutant));
+    this.mutants = input.mutants.map((mutantResult) => {
+      const mutant = new MutantModel(mutantResult);
+      mutant.sourceFile = this;
+      return mutant;
+    });
+  }
+
+  public getMutationLines(mutant: MutantResult): string {
+    assertSourceDefined(this.source);
+    const lineMap = this.getLineMap();
+    const start = lineMap[mutant.location.start.line];
+    const startOfEndLine = lineMap[mutant.location.end.line];
+    const end = lineMap[mutant.location.end.line + 1];
+    return `${this.source.substr(start, mutant.location.start.column - 1)}${
+      mutant.replacement ?? mutant.description ?? mutant.mutatorName
+    }${this.source.substring(startOfEndLine + mutant.location.end.column - 1, end)}`;
   }
 }

--- a/packages/mutation-testing-metrics/src/model/file-under-test-model.ts
+++ b/packages/mutation-testing-metrics/src/model/file-under-test-model.ts
@@ -1,6 +1,6 @@
 import { FileResult, MutantResult } from 'mutation-testing-report-schema';
 import { MutantModel } from './mutant-model';
-import { assertSourceDefined, SourceFile } from './source-file';
+import { SourceFile } from './source-file';
 
 /**
  * Represents a file which was mutated (your production code).
@@ -9,22 +9,24 @@ export class FileUnderTestModel extends SourceFile implements FileResult {
   /**
    * Programming language that is used. Used for code highlighting, see https://prismjs.com/#examples.
    */
-  language!: string;
+  language: string;
   /**
    * Full source code of the mutated file, this is used for highlighting.
    */
-  source!: string;
+  source: string;
   /**
    * The mutants inside this file.
    */
   mutants: MutantModel[];
 
-  constructor(input: FileResult) {
+  /**
+   * @param input The file result content
+   * @param name The file name
+   */
+  constructor(input: FileResult, public name: string) {
     super();
-    Object.entries(input).forEach(([key, value]) => {
-      // @ts-expect-error dynamic assignment so we won't forget to add new properties
-      this[key] = value;
-    });
+    this.language = input.language;
+    this.source = input.source;
     this.mutants = input.mutants.map((mutantResult) => {
       const mutant = new MutantModel(mutantResult);
       mutant.sourceFile = this;
@@ -32,8 +34,10 @@ export class FileUnderTestModel extends SourceFile implements FileResult {
     });
   }
 
+  /**
+   * Retrieves the lines of code with the mutant applied to it, to be shown in a diff view.
+   */
   public getMutationLines(mutant: MutantResult): string {
-    assertSourceDefined(this.source);
     const lineMap = this.getLineMap();
     const start = lineMap[mutant.location.start.line];
     const startOfEndLine = lineMap[mutant.location.end.line];

--- a/packages/mutation-testing-metrics/src/model/mutant-model.ts
+++ b/packages/mutation-testing-metrics/src/model/mutant-model.ts
@@ -12,27 +12,39 @@ function assertSourceFileDefined(sourceFile: FileUnderTestModel | undefined): as
  * Represent a model of a mutant that contains its test relationship
  */
 export class MutantModel implements MutantResult {
-  public coveredByTests: TestModel[] | undefined;
-  public killedByTests: TestModel[] | undefined;
+  // MutantResult properties
+
   public coveredBy: string[] | undefined;
   public description: string | undefined;
   public duration: number | undefined;
-  public id!: string;
+  public id: string;
   public killedBy: string[] | undefined;
-  public location!: Location;
-  public mutatorName!: string;
+  public location: Location;
+  public mutatorName: string;
   public replacement: string | undefined;
   public static: boolean | undefined;
-  public status!: MutantStatus;
-  public statusReason?: string;
+  public status: MutantStatus;
+  public statusReason: string | undefined;
   public testsCompleted: number | undefined;
+
+  // New fields
+  public coveredByTests: TestModel[] | undefined;
+  public killedByTests: TestModel[] | undefined;
   public sourceFile: FileUnderTestModel | undefined;
 
   constructor(input: MutantResult) {
-    Object.entries(input).forEach(([key, value]) => {
-      // @ts-expect-error dynamic assignment so we won't forget to add new properties
-      this[key] = value;
-    });
+    this.coveredBy = input.coveredBy;
+    this.description = input.description;
+    this.duration = input.duration;
+    this.id = input.id;
+    this.killedBy = input.killedBy;
+    this.location = input.location;
+    this.mutatorName = input.mutatorName;
+    this.replacement = input.replacement;
+    this.static = input.static;
+    this.status = input.status;
+    this.statusReason = input.statusReason;
+    this.testsCompleted = input.testsCompleted;
   }
 
   public addCoveredBy(test: TestModel) {
@@ -49,13 +61,28 @@ export class MutantModel implements MutantResult {
     this.killedByTests.push(test);
   }
 
+  /**
+   * Retrieves the lines of code with the mutant applied to it, to be shown in a diff view.
+   */
   public getMutatedLines() {
     assertSourceFileDefined(this.sourceFile);
     return this.sourceFile.getMutationLines(this);
   }
 
+  /**
+   * Retrieves the original source lines for this mutant, to be shown in a diff view.
+   */
   public getOriginalLines() {
     assertSourceFileDefined(this.sourceFile);
     return this.sourceFile.getLines(this.location);
+  }
+
+  /**
+   * Helper property to retrieve the source file name
+   * @throws When the `sourceFile` is not defined.
+   */
+  public get fileName() {
+    assertSourceFileDefined(this.sourceFile);
+    return this.sourceFile.name;
   }
 }

--- a/packages/mutation-testing-metrics/src/model/mutant-model.ts
+++ b/packages/mutation-testing-metrics/src/model/mutant-model.ts
@@ -1,5 +1,12 @@
 import { Location, MutantResult, MutantStatus } from 'mutation-testing-report-schema';
+import { FileUnderTestModel } from './file-under-test-model';
 import { TestModel } from './test-model';
+
+function assertSourceFileDefined(sourceFile: FileUnderTestModel | undefined): asserts sourceFile {
+  if (sourceFile === undefined) {
+    throw new Error('mutant.sourceFile was not defined');
+  }
+}
 
 /**
  * Represent a model of a mutant that contains its test relationship
@@ -19,6 +26,7 @@ export class MutantModel implements MutantResult {
   public status!: MutantStatus;
   public statusReason?: string;
   public testsCompleted: number | undefined;
+  public sourceFile: FileUnderTestModel | undefined;
 
   constructor(input: MutantResult) {
     Object.entries(input).forEach(([key, value]) => {
@@ -39,5 +47,15 @@ export class MutantModel implements MutantResult {
       this.killedByTests = [];
     }
     this.killedByTests.push(test);
+  }
+
+  public getMutatedLines() {
+    assertSourceFileDefined(this.sourceFile);
+    return this.sourceFile.getMutationLines(this);
+  }
+
+  public getOriginalLines() {
+    assertSourceFileDefined(this.sourceFile);
+    return this.sourceFile.getLines(this.location);
   }
 }

--- a/packages/mutation-testing-metrics/src/model/source-file.ts
+++ b/packages/mutation-testing-metrics/src/model/source-file.ts
@@ -1,4 +1,4 @@
-import { Location } from 'mutation-testing-report-schema';
+import { OpenEndLocation } from 'mutation-testing-report-schema';
 import { computeLineStarts } from '../helpers';
 
 export function assertSourceDefined(source: string | undefined): asserts source {
@@ -16,9 +16,9 @@ export abstract class SourceFile {
     return this.lineMap || (this.lineMap = computeLineStarts(this.source));
   }
 
-  public getLines(location: Location): string {
+  public getLines(location: OpenEndLocation): string {
     assertSourceDefined(this.source);
     const lineMap = this.getLineMap();
-    return this.source.substring(lineMap[location.start.line], lineMap[location.end.line + 1]);
+    return this.source.substring(lineMap[location.start.line], lineMap[(location.end ?? location.start).line + 1]);
   }
 }

--- a/packages/mutation-testing-metrics/src/model/source-file.ts
+++ b/packages/mutation-testing-metrics/src/model/source-file.ts
@@ -1,0 +1,24 @@
+import { Location } from 'mutation-testing-report-schema';
+import { computeLineStarts } from '../helpers';
+
+export function assertSourceDefined(source: string | undefined): asserts source {
+  if (source === undefined) {
+    throw new Error('sourceFile.source is undefined');
+  }
+}
+
+export abstract class SourceFile {
+  public abstract source: string | undefined;
+  private lineMap?: number[];
+
+  public getLineMap(): number[] {
+    assertSourceDefined(this.source);
+    return this.lineMap || (this.lineMap = computeLineStarts(this.source));
+  }
+
+  public getLines(location: Location): string {
+    assertSourceDefined(this.source);
+    const lineMap = this.getLineMap();
+    return this.source.substring(lineMap[location.start.line], lineMap[location.end.line + 1]);
+  }
+}

--- a/packages/mutation-testing-metrics/src/model/source-file.ts
+++ b/packages/mutation-testing-metrics/src/model/source-file.ts
@@ -16,6 +16,9 @@ export abstract class SourceFile {
     return this.lineMap || (this.lineMap = computeLineStarts(this.source));
   }
 
+  /**
+   * Retrieves the source lines based on the `start.line` and `end.line` property.
+   */
   public getLines(location: OpenEndLocation): string {
     assertSourceDefined(this.source);
     const lineMap = this.getLineMap();

--- a/packages/mutation-testing-metrics/src/model/test-file-model.ts
+++ b/packages/mutation-testing-metrics/src/model/test-file-model.ts
@@ -8,7 +8,12 @@ import { TestModel } from './test-model';
 export class TestFileModel extends SourceFile implements TestFile {
   tests: TestModel[];
   source: string | undefined;
-  constructor(input: TestFile) {
+
+  /**
+   * @param input the test file content
+   * @param name the file name
+   */
+  constructor(input: TestFile, public name: string) {
     super();
     this.source = input.source;
     this.tests = input.tests.map((testDefinition) => new TestModel(testDefinition));

--- a/packages/mutation-testing-metrics/src/model/test-file-model.ts
+++ b/packages/mutation-testing-metrics/src/model/test-file-model.ts
@@ -1,13 +1,15 @@
 import { TestFile as TestFile } from 'mutation-testing-report-schema';
+import { SourceFile } from './source-file';
 import { TestModel } from './test-model';
 
 /**
  * Represents a file that contains tests
  */
-export class TestFileModel implements TestFile {
+export class TestFileModel extends SourceFile implements TestFile {
   tests: TestModel[];
-  source?: string;
+  source: string | undefined;
   constructor(input: TestFile) {
+    super();
     this.source = input.source;
     this.tests = input.tests.map((testDefinition) => new TestModel(testDefinition));
   }

--- a/packages/mutation-testing-metrics/src/model/test-model.ts
+++ b/packages/mutation-testing-metrics/src/model/test-model.ts
@@ -1,13 +1,26 @@
 import { OpenEndLocation, TestDefinition } from 'mutation-testing-report-schema';
 import { MutantModel } from './mutant-model';
+import { TestFileModel } from './test-file-model';
+
+function assertSourceFileDefined(sourceFile: TestFileModel | undefined): asserts sourceFile {
+  if (sourceFile === undefined) {
+    throw new Error('test.sourceFile was not defined');
+  }
+}
+function assertLocationDefined(location: OpenEndLocation | undefined): asserts location {
+  if (location === undefined) {
+    throw new Error('test.location was not defined');
+  }
+}
 
 export class TestModel implements TestDefinition {
-  id!: string;
-  name!: string;
-  location?: OpenEndLocation | undefined;
+  public id!: string;
+  public name!: string;
+  public location?: OpenEndLocation | undefined;
 
-  killedMutants?: MutantModel[];
-  coveredMutants?: MutantModel[];
+  public killedMutants?: MutantModel[];
+  public coveredMutants?: MutantModel[];
+  public sourceFile: TestFileModel | undefined;
 
   public addCovered(mutant: MutantModel) {
     if (!this.coveredMutants) {
@@ -28,5 +41,11 @@ export class TestModel implements TestDefinition {
       // @ts-expect-error dynamic assignment so we won't forget to add new properties
       this[key] = value;
     });
+  }
+
+  public getLines(): string {
+    assertSourceFileDefined(this.sourceFile);
+    assertLocationDefined(this.location);
+    return this.sourceFile.getLines(this.location);
   }
 }

--- a/packages/mutation-testing-metrics/src/model/test-model.ts
+++ b/packages/mutation-testing-metrics/src/model/test-model.ts
@@ -43,9 +43,22 @@ export class TestModel implements TestDefinition {
     });
   }
 
+  /**
+   * Retrieves the original source lines where this test is defined.
+   * @throws if source file or location is not defined
+   */
   public getLines(): string {
     assertSourceFileDefined(this.sourceFile);
     assertLocationDefined(this.location);
     return this.sourceFile.getLines(this.location);
+  }
+
+  /**
+   * Helper property to retrieve the source file name
+   * @throws When the `sourceFile` is not defined.
+   */
+  public get fileName() {
+    assertSourceFileDefined(this.sourceFile);
+    return this.sourceFile.name;
   }
 }

--- a/packages/mutation-testing-metrics/test/helpers/factories.ts
+++ b/packages/mutation-testing-metrics/test/helpers/factories.ts
@@ -1,4 +1,13 @@
 import { FileResult, MutantResult, MutantStatus, MutationTestResult, TestDefinition, TestFile, Location } from 'mutation-testing-report-schema';
+import { FileUnderTestModel, TestFileModel } from '../../src';
+
+export function createTestFileModel(overrides?: Partial<TestFileModel>): TestFileModel {
+  return new TestFileModel(createTestFile(overrides), overrides?.name ?? 'foo.spec.js');
+}
+
+export function createFileUnderTestModel(overrides?: Partial<FileUnderTestModel>): FileUnderTestModel {
+  return new FileUnderTestModel(createFileResult(overrides), overrides?.name ?? 'foo.js');
+}
 
 export function createMutationTestResult(overrides?: Partial<MutationTestResult>): MutationTestResult {
   return {

--- a/packages/mutation-testing-metrics/test/unit/calculateMetrics.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/calculateMetrics.spec.ts
@@ -33,6 +33,7 @@ describe(calculateMetrics.name, () => {
     expect(actual.childResults[0].name).eq('bar');
     expect(actual.childResults[0].file).undefined;
     expect(actual.childResults[0].childResults[0].name).eq('baz.js');
+    expect(actual.childResults[0].childResults[0].file!.name).deep.eq('bar/baz.js');
     expect(actual.childResults[0].childResults[0].file!.source).deep.eq(baz.source);
     expect(actual.childResults[0].metrics).include({
       killed: 1,

--- a/packages/mutation-testing-metrics/test/unit/calculateMetrics.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/calculateMetrics.spec.ts
@@ -33,7 +33,7 @@ describe(calculateMetrics.name, () => {
     expect(actual.childResults[0].name).eq('bar');
     expect(actual.childResults[0].file).undefined;
     expect(actual.childResults[0].childResults[0].name).eq('baz.js');
-    expect(actual.childResults[0].childResults[0].file).deep.eq(baz);
+    expect(actual.childResults[0].childResults[0].file!.source).deep.eq(baz.source);
     expect(actual.childResults[0].metrics).include({
       killed: 1,
       survived: 1,
@@ -90,6 +90,20 @@ describe(calculateMetrics.name, () => {
     expect(actual.childResults[1].name).eq('foo');
     expect(actual.childResults[1].childResults[0].name).eq('bar');
     expect(actual.childResults[1].childResults[0].childResults[0].name).eq('baz.js');
+  });
+
+  it('should relate mutants with their source files', () => {
+    // Arrange
+    const input = {
+      'foo.js': createFileResult({ mutants: [createMutantResult()] }),
+    };
+
+    // Act
+    const actual = calculateMetrics(input);
+
+    // Assert
+    const file = actual.childResults[0].file!;
+    expect(file.mutants[0].sourceFile).eq(file);
   });
 
   it('should determine and strip the common root directory', () => {

--- a/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
@@ -34,6 +34,11 @@ describe(FileUnderTestModel.name, () => {
       const actual = sut.getLines({ start: { line: 3, column: 8 }, end: { line: 5, column: 2 } });
       expect(actual).eq('const baz = () => {\n  qux();\n};\n');
     });
+    it('should retrieve the starting line if presented with an open end location', () => {
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+      const actual = sut.getLines({ start: { line: 3, column: 8 }, end: undefined });
+      expect(actual).eq('const baz = () => {\n');
+    });
   });
 
   describe(FileUnderTestModel.prototype.getMutationLines.name, () => {

--- a/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
@@ -7,17 +7,52 @@ describe(FileUnderTestModel.name, () => {
   it('should copy over all values from file result', () => {
     const fileResult: Required<FileResult> = {
       language: 'js',
-      mutants: [createMutantResult({ id: 'mut-1' })],
+      mutants: [],
       source: 'foo(bar);',
     };
-    expect(new FileUnderTestModel(fileResult)).deep.eq(fileResult);
+    const actual = new FileUnderTestModel(fileResult);
+    expect(actual).deep.include(fileResult);
   });
 
-  it('should create mutant model objects', () => {
+  it('should create mutant model objects and relate itself to them', () => {
     const fileResult = createFileResult({
       mutants: [createMutantResult({ id: 'mut-1' })],
     });
     const actual = new FileUnderTestModel(fileResult);
     expect(actual.mutants[0]).instanceOf(MutantModel);
+    expect(actual.mutants[0].sourceFile).eq(actual);
+  });
+
+  describe(FileUnderTestModel.prototype.getLines.name, () => {
+    it('should retrieve a single line if the location spans a single line', () => {
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nbaz.qux()\n' }));
+      const actual = sut.getLines({ start: { line: 3, column: 1 }, end: { line: 3, column: 2 } });
+      expect(actual).eq('baz.qux()\n');
+    });
+    it('should retrieve 3 lines if the location spans a 3 lines', () => {
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+      const actual = sut.getLines({ start: { line: 3, column: 8 }, end: { line: 5, column: 2 } });
+      expect(actual).eq('const baz = () => {\n  qux();\n};\n');
+    });
+  });
+
+  describe(FileUnderTestModel.prototype.getMutationLines.name, () => {
+    let sut: FileUnderTestModel;
+
+    beforeEach(() => {
+      sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+    });
+
+    it('should be able to show a mutant spanning 1 line', () => {
+      const mutant = createMutantResult({ replacement: 'baz', location: { start: { line: 2, column: 5 }, end: { line: 2, column: 8 } } });
+      const actual = sut.getMutationLines(mutant);
+      expect(actual).eq('foo.baz();\n');
+    });
+
+    it('should return the mutated lines for a mutant spanning 3 lines', () => {
+      const mutant = createMutantResult({ replacement: '{}', location: { start: { line: 3, column: 19 }, end: { line: 5, column: 2 } } });
+      const actual = sut.getMutationLines(mutant);
+      expect(actual).eq('const baz = () => {};\n');
+    });
   });
 });

--- a/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/file-under-test-model.spec.ts
@@ -10,32 +10,37 @@ describe(FileUnderTestModel.name, () => {
       mutants: [],
       source: 'foo(bar);',
     };
-    const actual = new FileUnderTestModel(fileResult);
+    const actual = new FileUnderTestModel(fileResult, '');
     expect(actual).deep.include(fileResult);
+  });
+
+  it('should set the file name', () => {
+    const sut = new FileUnderTestModel(createFileResult(), 'bar.spec.js');
+    expect(sut.name).deep.eq('bar.spec.js');
   });
 
   it('should create mutant model objects and relate itself to them', () => {
     const fileResult = createFileResult({
       mutants: [createMutantResult({ id: 'mut-1' })],
     });
-    const actual = new FileUnderTestModel(fileResult);
+    const actual = new FileUnderTestModel(fileResult, '');
     expect(actual.mutants[0]).instanceOf(MutantModel);
     expect(actual.mutants[0].sourceFile).eq(actual);
   });
 
   describe(FileUnderTestModel.prototype.getLines.name, () => {
     it('should retrieve a single line if the location spans a single line', () => {
-      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nbaz.qux()\n' }));
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nbaz.qux()\n' }), '');
       const actual = sut.getLines({ start: { line: 3, column: 1 }, end: { line: 3, column: 2 } });
       expect(actual).eq('baz.qux()\n');
     });
     it('should retrieve 3 lines if the location spans a 3 lines', () => {
-      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }), '');
       const actual = sut.getLines({ start: { line: 3, column: 8 }, end: { line: 5, column: 2 } });
       expect(actual).eq('const baz = () => {\n  qux();\n};\n');
     });
     it('should retrieve the starting line if presented with an open end location', () => {
-      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+      const sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }), '');
       const actual = sut.getLines({ start: { line: 3, column: 8 }, end: undefined });
       expect(actual).eq('const baz = () => {\n');
     });
@@ -45,7 +50,7 @@ describe(FileUnderTestModel.name, () => {
     let sut: FileUnderTestModel;
 
     beforeEach(() => {
-      sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }));
+      sut = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nconst baz = () => {\n  qux();\n};\n' }), '');
     });
 
     it('should be able to show a mutant spanning 1 line', () => {

--- a/packages/mutation-testing-metrics/test/unit/model/mutant-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/mutant-model.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { MutantResult, MutantStatus } from 'mutation-testing-report-schema';
-import { FileUnderTestModel, MutantModel, TestModel } from '../../../src';
-import { createFileResult, createLocation, createMutantResult, createTestDefinition } from '../../helpers/factories';
+import { MutantModel, TestModel } from '../../../src';
+import { createFileUnderTestModel, createLocation, createMutantResult, createTestDefinition } from '../../helpers/factories';
 
 describe(MutantModel.name, () => {
   it('should copy over all values from mutant result', () => {
@@ -55,7 +55,7 @@ describe(MutantModel.name, () => {
       const sut = new MutantModel(
         createMutantResult({ replacement: 'baz', location: { start: { line: 2, column: 5 }, end: { line: 2, column: 8 } } })
       );
-      sut.sourceFile = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\n qux()\n' }));
+      sut.sourceFile = createFileUnderTestModel({ source: '\nfoo.bar();\n qux()\n' });
       const actual = sut.getMutatedLines();
       expect(actual).eq('foo.baz();\n');
     });
@@ -69,7 +69,7 @@ describe(MutantModel.name, () => {
   describe(MutantModel.prototype.getOriginalLines.name, () => {
     it('should be able to show a mutant spanning 1 line', () => {
       const sut = new MutantModel(createMutantResult({ location: { start: { line: 3, column: 1 }, end: { line: 3, column: 2 } } }));
-      sut.sourceFile = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nbaz.qux()\n' }));
+      sut.sourceFile = createFileUnderTestModel({ source: '\nfoo.bar();\nbaz.qux()\n' });
       const actual = sut.getOriginalLines();
       expect(actual).eq('baz.qux()\n');
     });

--- a/packages/mutation-testing-metrics/test/unit/model/mutant-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/mutant-model.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { MutantResult, MutantStatus } from 'mutation-testing-report-schema';
-import { MutantModel, TestModel } from '../../../src';
-import { createLocation, createMutantResult, createTestDefinition } from '../../helpers/factories';
+import { FileUnderTestModel, MutantModel, TestModel } from '../../../src';
+import { createFileResult, createLocation, createMutantResult, createTestDefinition } from '../../helpers/factories';
 
 describe(MutantModel.name, () => {
   it('should copy over all values from mutant result', () => {
@@ -47,6 +47,36 @@ describe(MutantModel.name, () => {
         actual[method](test2);
         expect(actual[property]).deep.eq([test, test2]);
       });
+    });
+  });
+
+  describe(MutantModel.prototype.getMutatedLines.name, () => {
+    it('should be able to show a mutant spanning 1 line', () => {
+      const sut = new MutantModel(
+        createMutantResult({ replacement: 'baz', location: { start: { line: 2, column: 5 }, end: { line: 2, column: 8 } } })
+      );
+      sut.sourceFile = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\n qux()\n' }));
+      const actual = sut.getMutatedLines();
+      expect(actual).eq('foo.baz();\n');
+    });
+
+    it("should throw if the sourceFile wasn't set", () => {
+      const sut = new MutantModel(createMutantResult());
+      expect(() => sut.getMutatedLines()).throws('mutant.sourceFile was not defined');
+    });
+  });
+
+  describe(MutantModel.prototype.getOriginalLines.name, () => {
+    it('should be able to show a mutant spanning 1 line', () => {
+      const sut = new MutantModel(createMutantResult({ location: { start: { line: 3, column: 1 }, end: { line: 3, column: 2 } } }));
+      sut.sourceFile = new FileUnderTestModel(createFileResult({ source: '\nfoo.bar();\nbaz.qux()\n' }));
+      const actual = sut.getOriginalLines();
+      expect(actual).eq('baz.qux()\n');
+    });
+
+    it("should throw if the sourceFile wasn't set", () => {
+      const sut = new MutantModel(createMutantResult());
+      expect(() => sut.getOriginalLines()).throws('mutant.sourceFile was not defined');
     });
   });
 });

--- a/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
@@ -21,7 +21,7 @@ describe(TestFileModel.name, () => {
   });
 
   describe(TestFileModel.prototype.getLines.name, () => {
-    // Implementation is tested in file-under-test-model.spec.ts
+    // Implementation of `getLines(location)` is tested in file-under-test-model.spec.ts
 
     it('should throw when the source is undefined', () => {
       const sut = new TestFileModel(createTestFile({ source: undefined }));

--- a/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TestFile } from 'mutation-testing-report-schema';
 import { TestFileModel, TestModel } from '../../../src';
-import { createTestDefinition, createTestFile } from '../../helpers/factories';
+import { createLocation, createTestDefinition, createTestFile } from '../../helpers/factories';
 
 describe(TestFileModel.name, () => {
   it('should copy over all values from file result', () => {
@@ -18,5 +18,14 @@ describe(TestFileModel.name, () => {
     });
     const actual = new TestFileModel(testFile);
     expect(actual.tests[0]).instanceOf(TestModel);
+  });
+
+  describe(TestFileModel.prototype.getLines.name, () => {
+    // Implementation is tested in file-under-test-model.spec.ts
+
+    it('should throw when the source is undefined', () => {
+      const sut = new TestFileModel(createTestFile({ source: undefined }));
+      expect(() => sut.getLines(createLocation())).throws('sourceFile.source is undefined');
+    });
   });
 });

--- a/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/test-file-model.spec.ts
@@ -9,14 +9,19 @@ describe(TestFileModel.name, () => {
       source: 'describe("foo")',
       tests: [createTestDefinition({ id: 'mut-1' })],
     };
-    expect(new TestFileModel(fileResult)).deep.eq(fileResult);
+    expect(new TestFileModel(fileResult, '')).deep.contains(fileResult);
+  });
+
+  it('should set the file name', () => {
+    const sut = new TestFileModel(createTestFile(), 'bar.spec.js');
+    expect(sut.name).deep.eq('bar.spec.js');
   });
 
   it('should create test model instances', () => {
     const testFile = createTestFile({
       tests: [createTestDefinition({ id: 'test-1' })],
     });
-    const actual = new TestFileModel(testFile);
+    const actual = new TestFileModel(testFile, '');
     expect(actual.tests[0]).instanceOf(TestModel);
   });
 
@@ -24,7 +29,7 @@ describe(TestFileModel.name, () => {
     // Implementation of `getLines(location)` is tested in file-under-test-model.spec.ts
 
     it('should throw when the source is undefined', () => {
-      const sut = new TestFileModel(createTestFile({ source: undefined }));
+      const sut = new TestFileModel(createTestFile({ source: undefined }), '');
       expect(() => sut.getLines(createLocation())).throws('sourceFile.source is undefined');
     });
   });

--- a/packages/mutation-testing-metrics/test/unit/model/test-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/test-model.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TestDefinition } from 'mutation-testing-report-schema';
-import { MutantModel, TestModel } from '../../../src';
-import { createLocation, createMutantResult, createTestDefinition } from '../../helpers/factories';
+import { MutantModel, TestFileModel, TestModel } from '../../../src';
+import { createLocation, createMutantResult, createTestDefinition, createTestFile } from '../../helpers/factories';
 
 describe(TestModel.name, () => {
   it('should copy over all values from mutant result', () => {
@@ -38,6 +38,25 @@ describe(TestModel.name, () => {
         actual[method](mutant2);
         expect(actual[property]).deep.eq([mutant, mutant2]);
       });
+    });
+  });
+
+  describe(TestModel.prototype.getLines.name, () => {
+    // Implementation of `getLines(location)` is tested in file-under-test-model.spec.ts
+
+    it('should return the line of the test', () => {
+      const sut = new TestModel(createTestDefinition({ location: { start: { line: 2, column: 1 } } }));
+      sut.sourceFile = new TestFileModel(createTestFile({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' }));
+      expect(sut.getLines()).eq('it("should work", () => {\n');
+    });
+    it('should throw when sourceFile is undefined', () => {
+      const sut = new TestModel(createTestDefinition({ location: { start: { line: 2, column: 1 } } }));
+      expect(() => sut.getLines()).throws('test.sourceFile was not defined');
+    });
+    it('should throw when location is undefined', () => {
+      const sut = new TestModel(createTestDefinition({ location: undefined }));
+      sut.sourceFile = new TestFileModel(createTestFile({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' }));
+      expect(() => sut.getLines()).throws('test.location was not defined');
     });
   });
 });

--- a/packages/mutation-testing-metrics/test/unit/model/test-model.spec.ts
+++ b/packages/mutation-testing-metrics/test/unit/model/test-model.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TestDefinition } from 'mutation-testing-report-schema';
-import { MutantModel, TestFileModel, TestModel } from '../../../src';
-import { createLocation, createMutantResult, createTestDefinition, createTestFile } from '../../helpers/factories';
+import { MutantModel, TestModel } from '../../../src';
+import { createLocation, createMutantResult, createTestDefinition, createTestFileModel } from '../../helpers/factories';
 
 describe(TestModel.name, () => {
   it('should copy over all values from mutant result', () => {
@@ -46,7 +46,7 @@ describe(TestModel.name, () => {
 
     it('should return the line of the test', () => {
       const sut = new TestModel(createTestDefinition({ location: { start: { line: 2, column: 1 } } }));
-      sut.sourceFile = new TestFileModel(createTestFile({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' }));
+      sut.sourceFile = createTestFileModel({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' });
       expect(sut.getLines()).eq('it("should work", () => {\n');
     });
     it('should throw when sourceFile is undefined', () => {
@@ -55,7 +55,7 @@ describe(TestModel.name, () => {
     });
     it('should throw when location is undefined', () => {
       const sut = new TestModel(createTestDefinition({ location: undefined }));
-      sut.sourceFile = new TestFileModel(createTestFile({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' }));
+      sut.sourceFile = createTestFileModel({ source: '\nit("should work", () => {\n  expect(foo()).eq("bar");\n});' });
       expect(() => sut.getLines()).throws('test.location was not defined');
     });
   });


### PR DESCRIPTION
Enrich model with helper methods for reporters:
* `mutant.getOriginalLines()`
* `mutant.getMutatedLines()`
* `test.getLines()`
* `mutant.fileName`
* `mutant.sourceFile`
* `test.fileName`
* `test.sourceFile`
* `fileUnderTest.name`
* `testFile.name`

Also:
* Add mechanism to determine character range based on line/column position (heavily inspired by TypeScript source code)
* Add a reference to the source file in each mutant.
* Refactor: split helpers over multiple files.
