### PR TITLE
test: add waitUntil helper function

### DIFF
--- a/packages/elements/test/integration/drawer.it.spec.ts
+++ b/packages/elements/test/integration/drawer.it.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { getCurrent } from './lib/browser';
-import { sleep } from './lib/helpers';
+import { waitUntil } from './lib/helpers';
 import { MutantComponent } from './po/MutantComponent.po';
 import { Drawer } from './po/Drawer.po';
 import { ReportPage } from './po/ReportPage';
@@ -59,9 +59,10 @@ describe('Drawer', () => {
 
       it('should show the details of the next mutant when another mutant is selected', async () => {
         await page.mutantView.mutant(24).toggleMutant();
-        await sleep();
-        expect(await drawer.isHalfOpen()).true;
-        expect(await drawer.headerText()).eq('24 👽 ConditionalExpression Survived (15:77)');
+        await waitUntil(async () => {
+          expect(await drawer.isHalfOpen()).true;
+          return expect(await drawer.headerText()).eq('24 👽 ConditionalExpression Survived (15:77)');
+        });
       });
 
       it('should hide the drawer when the user clicks somewhere else', async () => {
@@ -72,8 +73,8 @@ describe('Drawer', () => {
       it('should not hide the drawer when the user clicks somewhere on the drawer', async () => {
         await drawer.whenHalfOpen();
         await drawer.clickOnHeader();
-        await sleep();
-        expect(await drawer.isHalfOpen()).true;
+
+        await waitUntil(async () => expect(await drawer.isHalfOpen()).true);
       });
 
       describe('when "read more" is toggled', () => {
@@ -137,8 +138,8 @@ describe('Drawer', () => {
     it('should not hide the drawer when the user clicks somewhere on the drawer', async () => {
       await drawer.whenHalfOpen();
       await drawer.clickOnHeader();
-      await sleep();
-      expect(await drawer.isHalfOpen()).true;
+
+      await waitUntil(async () => expect(await drawer.isHalfOpen()).true);
     });
 
     describe('when "read more" is toggled', () => {

--- a/packages/elements/test/integration/test-view.it.spec.ts
+++ b/packages/elements/test/integration/test-view.it.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TestStatus } from 'mutation-testing-metrics';
 import { getCurrent } from './lib/browser';
-import { sleep } from './lib/helpers';
+import { waitUntil } from './lib/helpers';
 import { ReportPage } from './po/ReportPage';
 import { TestListItem } from './po/TestListItem.po';
 
@@ -32,9 +32,11 @@ describe('Test view', () => {
 
     it('should hide tests that are filtered out', async () => {
       await page.testView.stateFilter.state(TestStatus.Covering).click();
-      await sleep();
-      const tests = await page.testView.tests();
-      expect(await tests[1].isVisible()).false;
+
+      await waitUntil(async () => {
+        const tests = await page.testView.tests();
+        return expect(await tests[1].isVisible()).false;
+      });
     });
 
     it('should show the drawer when selecting a test', async () => {


### PR DESCRIPTION
Add a `waitUntil` function that waits until a certain given (async) condition is true, using intervals and timeouts. Based on `open-wc` (see link in comment), but with added support for Chai assertions.

My hope is this will also make the windows tests more stable
