### PR TITLE
test: disable flaky screenshot tests

### DIFF
--- a/packages/elements/test/integration/drawer.it.spec.ts
+++ b/packages/elements/test/integration/drawer.it.spec.ts
@@ -92,7 +92,8 @@ describe('Drawer', () => {
           await actScreenshotMatch(this);
         });
 
-        it('should look as expected in dark mode', async function () {
+        // Flaky test, disable until we find a good fix
+        it.skip('should look as expected in dark mode', async function () {
           await page.themeSelector.select('dark');
           await actScreenshotMatch(this);
         });
@@ -157,7 +158,8 @@ describe('Drawer', () => {
         await actScreenshotMatch(this);
       });
 
-      it('should look as expected in dark mode', async function () {
+      // Flaky test, disable until we find a good fix
+      it.skip('should look as expected in dark mode', async function () {
         await page.themeSelector.select('dark');
         await actScreenshotMatch(this);
       });


### PR DESCRIPTION
Looking at all the open PR's with failing builds, it's always one of these two tests that fail. Since there is also a test for light mode, I think it's somewhat safe to disable these two to (hopefully) increase screenshot test stability.
