### PR TITLE
perf/improve rendering performance

### DIFF
--- a/packages/elements/src/components/app/app.component.ts
+++ b/packages/elements/src/components/app/app.component.ts
@@ -107,10 +107,14 @@ export class MutationTestReportAppComponent extends LitElement {
   }
 
   public async updated(changedProperties: PropertyValues) {
-    if ((changedProperties.has('path') || changedProperties.has('report')) && this.report) {
-      this.updateModel(this.report);
-      this.updateContext();
-      this.updateTitle();
+    if (this.report) {
+      if (changedProperties.has('report')) {
+        this.updateModel(this.report);
+      }
+      if (changedProperties.has('path') || changedProperties.has('report')) {
+        this.updateContext();
+        this.updateTitle();
+      }
     }
     if (changedProperties.has('src')) {
       await this.loadData();

--- a/packages/metrics/src/calculateMetrics.ts
+++ b/packages/metrics/src/calculateMetrics.ts
@@ -106,17 +106,22 @@ function toChildModels<TFileModel, TMetrics>(
 }
 
 function relate(mutants: MutantModel[], tests: TestModel[]) {
+  // Create a testId -> TestModel map for fast lookup
+  const testMap: Map<string, TestModel> = new Map(tests.map((test) => [test.id, test]));
+
   for (const mutant of mutants) {
-    if (mutant.coveredBy || mutant.killedBy) {
-      for (const test of tests) {
-        if (mutant.coveredBy?.includes(test.id)) {
-          mutant.addCoveredBy(test);
-          test.addCovered(mutant);
-        }
-        if (mutant.killedBy?.includes(test.id)) {
-          mutant.addKilledBy(test);
-          test.addKilled(mutant);
-        }
+    const coveringTests = mutant.coveredBy?.map((testId) => testMap.get(testId)) ?? [];
+    for (const test of coveringTests) {
+      if (test) {
+        mutant.addCoveredBy(test);
+        test.addCovered(mutant);
+      }
+    }
+    const killingTests = mutant.killedBy?.map((testId) => testMap.get(testId)) ?? [];
+    for (const test of killingTests) {
+      if (test) {
+        mutant.addKilledBy(test);
+        test.addKilled(mutant);
       }
     }
   }

--- a/packages/metrics/test/unit/calculateMetrics.spec.ts
+++ b/packages/metrics/test/unit/calculateMetrics.spec.ts
@@ -195,7 +195,7 @@ describe(calculateMutationTestMetrics.name, () => {
     expect(mutant1?.killedByTests).deep.eq([test2]);
     expect(mutant1?.coveredByTests).deep.eq([test1, test2, test3]);
     expect(mutant2?.killedByTests).undefined;
-    expect(mutant2?.coveredByTests).deep.eq([test1, test4]);
+    expect(mutant2?.coveredByTests).deep.eq([test4, test1]);
     expect(test1.coveredMutants).deep.eq([mutant1, mutant2]);
     expect(test1.killedMutants).undefined;
     expect(test2.coveredMutants).deep.eq([mutant1]);


### PR DESCRIPTION
Fixes #1478

This PR has two commits to improve performance:

- perf(mutation-test-report-app): only recalculate metrics if report changed
  - Before, every time you navigate the `app` component would think there's an update to `report`, and re-calculate the metrics. This is a small change to only re-calculate the report when the report actually changes. If calculating the report is really slow, you'll now only notice it when opening the report the first time, instead of on every page navigation.
- perf(metrics): use Map for fast testId -> TestModel lookup
  - Relating tests to mutants' `coveredBy` and `killedBy` properties had a Big O of O(n^2) because for each mutant, it would loop through all the tests. The `relate` function in `calculateMetrics` also shows up in performance profiles as 99% of the time taken on a big report. Instead of the quadratic performance hit, `relate` now uses a `Map` to efficiently lookup a test to testIds from a mutant. When benchmarking with `console.time` on my machine in Edge with the large report in #1478, the `relate` function now takes about 180ms instead of 3.7 seconds, which makes opening the large report pretty much instant.
 
Before:
![image](https://user-images.githubusercontent.com/10114577/145397813-ee621e4a-5961-4e51-aaab-79e26bb542ad.png)

After:
![image](https://user-images.githubusercontent.com/10114577/145397655-0dd55f56-e483-4f9f-8aee-3fb22d7d8bf4.png)

