### PR TITLE
fix(mutation-testing-elements): Don't render statusreason if it's an empty string

### DIFF
--- a/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
+++ b/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
@@ -52,7 +52,9 @@ export class MutationTestReportDrawerMutant extends LitElement {
             ${renderIf(this.mutant?.status === MutantStatus.Survived, '(yet still survived)')}</h6
           >`
       )}
-      ${renderIf(this.mutant?.statusReason?.trim(), html`<h6 class="pe-4" title="Reason for the ${this.mutant!.status} status">🕵️ ${this.mutant!.statusReason}</h6>`
+      ${renderIf(
+        this.mutant?.statusReason?.trim(),
+        html`<h6 class="pe-4" title="Reason for the ${this.mutant!.status} status">🕵️ ${this.mutant!.statusReason}</h6>`
       )}
       ${renderIfPresent(this.mutant?.description, (description) => html`<h6 class="pe-4">📖 ${description}</h6>`)}
     </div>`;

--- a/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
+++ b/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
@@ -52,9 +52,7 @@ export class MutationTestReportDrawerMutant extends LitElement {
             ${renderIf(this.mutant?.status === MutantStatus.Survived, '(yet still survived)')}</h6
           >`
       )}
-      ${renderIfPresent(
-        this.mutant?.statusReason,
-        (reason) => html`<h6 class="pe-4" title="Reason for the ${this.mutant!.status} status">🕵️ ${reason}</h6>`
+      ${renderIf(this.mutant?.statusReason?.trim(), html`<h6 class="pe-4" title="Reason for the ${this.mutant!.status} status">🕵️ ${this.mutant!.statusReason}</h6>`
       )}
       ${renderIfPresent(this.mutant?.description, (description) => html`<h6 class="pe-4">📖 ${description}</h6>`)}
     </div>`;

--- a/packages/elements/test/unit/components/drawer-mutant.component.spec.ts
+++ b/packages/elements/test/unit/components/drawer-mutant.component.spec.ts
@@ -113,6 +113,15 @@ describe(MutationTestReportDrawerMutant.name, () => {
         expect(summary).contains('🕵️ Hit limit reached (501 > 500)');
       });
 
+      it('should not render the status reason when it is empty', async () => {
+        mutant.status = MutantStatus.Timeout;
+        mutant.statusReason = '   ';
+        sut.element.mutant = mutant;
+        await sut.whenStable();
+        const summary = summaryText();
+        expect(summary).not.contains('🕵️');
+      });
+
       function summaryText() {
         return sut.$<HTMLElement>('[slot="summary"]').innerText;
       }


### PR DESCRIPTION
Related to #1619 