### PR TITLE
fix(aggregate): also make ids unique

### DIFF
--- a/packages/metrics/src/aggregate.ts
+++ b/packages/metrics/src/aggregate.ts
@@ -55,6 +55,6 @@ function toUniqueIds(moduleName: string, localIds: string[] | undefined): string
   return;
 }
 
-function toUniqueId(moduleName: string, localeId: string) {
-  return `${moduleName}_${localeId}`;
+function toUniqueId(moduleName: string, localId: string) {
+  return `${moduleName}_${localId}`;
 }

--- a/packages/metrics/test/unit/aggregate.spec.ts
+++ b/packages/metrics/test/unit/aggregate.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { MutationTestResult } from 'mutation-testing-report-schema/api';
 import { aggregateResultsByModule } from '../../src';
-import { createFileResult, createMutationTestResult, createTestFile } from '../helpers/factories';
+import { createFileResult, createMutantResult, createMutationTestResult, createTestDefinition, createTestFile } from '../helpers/factories';
 
 describe(aggregateResultsByModule.name, () => {
   it('should result in an empty report when an empty object is provided', () => {
@@ -38,15 +38,15 @@ describe(aggregateResultsByModule.name, () => {
 
   describe('files', () => {
     it('should prefix files with the module name', () => {
-      const file = createFileResult();
+      const file = createFileResult({ mutants: [] });
       const module = createMutationTestResult({ files: { a: file } });
       const result = aggregateResultsByModule({ module });
       expect(result.files).deep.eq({ 'module/a': file });
     });
     it('should merge file results together', () => {
-      const fileA = createFileResult();
-      const fileB = createFileResult();
-      const fileC = createFileResult();
+      const fileA = createFileResult({ source: 'core/a', mutants: [] });
+      const fileB = createFileResult({ source: 'core/b', mutants: [] });
+      const fileC = createFileResult({ source: 'api/c', mutants: [] });
       const core = createMutationTestResult({ files: { a: fileA, b: fileB } });
       const api = createMutationTestResult({ files: { a: fileC } });
       const result = aggregateResultsByModule({ core, api });
@@ -56,27 +56,102 @@ describe(aggregateResultsByModule.name, () => {
 
   describe('testFiles', () => {
     it('should prefix test files with the module name', () => {
-      const file = createTestFile();
+      const file = createTestFile({ tests: [] });
       const module = createMutationTestResult({ testFiles: { a: file } });
       const result = aggregateResultsByModule({ module });
       expect(result.testFiles).deep.eq({ 'module/a': file });
     });
     it('should merge test file results together', () => {
-      const fileA = createTestFile();
-      const fileB = createTestFile();
-      const fileC = createTestFile();
+      const fileA = createTestFile({ source: 'fileA', tests: [] });
+      const fileB = createTestFile({ source: 'fileB', tests: [] });
+      const fileC = createTestFile({ source: 'fileC', tests: [] });
       const core = createMutationTestResult({ testFiles: { a: fileA, b: fileB } });
       const api = createMutationTestResult({ testFiles: { a: fileC } });
       const result = aggregateResultsByModule({ core, api });
       expect(result.testFiles).deep.eq({ 'core/a': fileA, 'core/b': fileB, 'api/a': fileC });
     });
     it('should allow undefined test files', () => {
-      const fileA = createTestFile();
-      const fileB = createTestFile();
+      const fileA = createTestFile({ source: 'fileA', tests: [] });
+      const fileB = createTestFile({ source: 'fileB', tests: [] });
       const core = createMutationTestResult({ testFiles: { a: fileA, b: fileB } });
       const api = createMutationTestResult({ testFiles: undefined });
       const result = aggregateResultsByModule({ core, api });
       expect(result.testFiles).deep.eq({ 'core/a': fileA, 'core/b': fileB });
+    });
+  });
+
+  describe('mutants', () => {
+    it('should prefix mutant ids with moduleName', () => {
+      // Arrange
+      const fileA = createFileResult({ mutants: [createMutantResult({ id: '1' })] });
+      const fileB = createFileResult({ mutants: [createMutantResult({ id: '1' })] });
+      const core = createMutationTestResult({ files: { a: fileA } });
+      const api = createMutationTestResult({ files: { b: fileB } });
+
+      // Act
+      const result = aggregateResultsByModule({ core, api });
+
+      // Assert
+      const mutantsCore = result.files['core/a'].mutants;
+      const mutantsApi = result.files['api/b'].mutants;
+      expect(mutantsCore).lengthOf(1);
+      expect(mutantsApi).lengthOf(1);
+      expect(mutantsCore[0].id).eq('core_1');
+      expect(mutantsApi[0].id).eq('api_1');
+    });
+
+    it('should prefix coveredBy with moduleName', () => {
+      // Arrange
+      const fileA = createFileResult({ mutants: [createMutantResult({ coveredBy: ['1'] })] });
+      const fileB = createFileResult({ mutants: [createMutantResult({ coveredBy: ['1', '2'] })] });
+      const core = createMutationTestResult({ files: { a: fileA } });
+      const api = createMutationTestResult({ files: { b: fileB } });
+
+      // Act
+      const result = aggregateResultsByModule({ core, api });
+
+      // Assert
+      const [mutantCore] = result.files['core/a'].mutants;
+      const [mutantApi] = result.files['api/b'].mutants;
+      expect(mutantCore.coveredBy).deep.eq(['core_1']);
+      expect(mutantApi.coveredBy).deep.eq(['api_1', 'api_2']);
+    });
+
+    it('should prefix killedBy with moduleName', () => {
+      // Arrange
+      const fileA = createFileResult({ mutants: [createMutantResult({ killedBy: ['1'] })] });
+      const fileB = createFileResult({ mutants: [createMutantResult({ killedBy: ['1', '2'] })] });
+      const core = createMutationTestResult({ files: { a: fileA } });
+      const api = createMutationTestResult({ files: { b: fileB } });
+
+      // Act
+      const result = aggregateResultsByModule({ core, api });
+
+      // Assert
+      const [mutantCore] = result.files['core/a'].mutants;
+      const [mutantApi] = result.files['api/b'].mutants;
+      expect(mutantCore.killedBy).deep.eq(['core_1']);
+      expect(mutantApi.killedBy).deep.eq(['api_1', 'api_2']);
+    });
+  });
+  describe('tests', () => {
+    it('should prefix test ids with moduleName', () => {
+      // Arrange
+      const fileA = createTestFile({ tests: [createTestDefinition({ id: '1' })] });
+      const fileB = createTestFile({ tests: [createTestDefinition({ id: '1' })] });
+      const core = createMutationTestResult({ testFiles: { a: fileA } });
+      const api = createMutationTestResult({ testFiles: { b: fileB } });
+
+      // Act
+      const result = aggregateResultsByModule({ core, api });
+
+      // Assert
+      const testsCore = result.testFiles!['core/a'].tests;
+      const testsApi = result.testFiles!['api/b'].tests;
+      expect(testsCore).lengthOf(1);
+      expect(testsApi).lengthOf(1);
+      expect(testsCore[0].id).eq('core_1');
+      expect(testsApi[0].id).eq('api_1');
     });
   });
 });


### PR DESCRIPTION
Make testIds and mutantIds unique accross all modules in `aggregateResultsByModule`

Fixes #1672