### PR TITLE
fix: Set theme color for ignored status mutants

### DIFF
--- a/packages/elements/src/components/file/file.scss
+++ b/packages/elements/src/components/file/file.scss
@@ -10,7 +10,7 @@ $mutant-themes: (
   'Timeout': 'warning',
   'CompileError': 'secondary',
   'RuntimeError': 'secondary',
-  'Ignored': 'secondary'
+  'Ignored': 'secondary',
 );
 
 // These 2 themes get underlined with a squiggly (wavy) for extra emphasis

--- a/packages/elements/src/components/file/file.scss
+++ b/packages/elements/src/components/file/file.scss
@@ -10,6 +10,7 @@ $mutant-themes: (
   'Timeout': 'warning',
   'CompileError': 'secondary',
   'RuntimeError': 'secondary',
+  'Ignored': 'secondary'
 );
 
 // These 2 themes get underlined with a squiggly (wavy) for extra emphasis


### PR DESCRIPTION
Fix #1937

Note that I did not manage to test the change as I could not figure out how to and there are no docs describing how to contribute.