### PR TITLE
fix: don't create test metrics if test files is empty

### DIFF
--- a/packages/elements/test/unit/components/app.component.spec.ts
+++ b/packages/elements/test/unit/components/app.component.spec.ts
@@ -46,7 +46,7 @@ describe(MutationTestReportAppComponent.name, () => {
   });
 
   describe('`src` attribute', () => {
-    it('should should fetch report data when updated', async () => {
+    it('should fetch report data when updated', async () => {
       // Arrange
       const response: Pick<Response, 'json'> = {
         json: () => Promise.resolve(expectedReport),
@@ -93,6 +93,26 @@ describe(MutationTestReportAppComponent.name, () => {
       sut.element.report = createReport();
       await sut.whenStable();
       expect(sut.$('mte-mutant-view')).ok;
+    });
+
+    it('should load navigation when testFiles are present', async () => {
+      sut.element.report = createReport({
+        testFiles: {
+          'foobar.spec.js': {
+            tests: [],
+          },
+        },
+      });
+      await sut.whenStable();
+      expect(sut.$('nav')).ok;
+    });
+
+    it('should not load navigation if testFiles object is empty', async () => {
+      sut.element.report = createReport({
+        testFiles: {},
+      });
+      await sut.whenStable();
+      expect(sut.$('nav')).null;
     });
   });
 

--- a/packages/elements/testResources/csharp-example/mutation-report.json
+++ b/packages/elements/testResources/csharp-example/mutation-report.json
@@ -5,6 +5,7 @@
     "high": 80
   },
   "projectRoot": "c:\\z\\github\\stryker-mutator\\mutation-testing-elements\\testResources\\csharp-example",
+  "testFiles": {},
   "files": {
     "ExampleProject\\DummyCalc.cs": {
       "source": "using ExampleClassLibrary;\r\n\r\nnamespace ExampleProject\r\n{\r\n    public class DummyCalc\r\n    {\r\n        public int SomeCalc(int first, int second)\r\n        {\r\n\t\t\twhile(second > 0) {\r\n\t\t\t\tfirst = first + second + 1;\r\n\t\t\t\tsecond--;\r\n\t\t\t}\r\n\t\t\twhile(1 < 0) {\r\n\t\t\t\t// endless looping\r\n\t\t\t}\r\n            return first;\r\n        }\r\n\r\n        public int Recursive(int n)\r\n        {\r\n            var recursive = new RecursiveMath();\r\n            return recursive.Fibinacci(n);\r\n        }\r\n    }\r\n}\r\n",

--- a/packages/metrics/src/calculateMetrics.ts
+++ b/packages/metrics/src/calculateMetrics.ts
@@ -25,7 +25,7 @@ export function calculateMetrics(files: Record<string, FileResult>): MetricsResu
 export function calculateMutationTestMetrics(result: MutationTestResult): MutationTestMetricsResult {
   const { files, testFiles, projectRoot = '' } = result;
   const fileModelsUnderTest = normalize(files, projectRoot, (input, name) => new FileUnderTestModel(input, name));
-  if (testFiles) {
+  if (testFiles && Object.keys(testFiles).length) {
     const testFileModels = normalize(testFiles, projectRoot, (input, name) => new TestFileModel(input, name));
     relate(
       Object.values(fileModelsUnderTest).flatMap((file) => file.mutants),


### PR DESCRIPTION
fix #1782 