### PR TITLE
fix(elements-table): transition score colors

### DIFF
--- a/packages/elements/src/components/metrics-table/metrics-table.component.ts
+++ b/packages/elements/src/components/metrics-table/metrics-table.component.ts
@@ -144,7 +144,7 @@ export class MutationTestReportTestMetricsTable<TFile, TMetric> extends Realtime
           ${valueIsPresent
             ? html`<div class="h-3 w-full min-w-[24px] rounded-full bg-gray-300">
                 <div
-                  class="${bgColoringClass} h-3 rounded-full pl-1 transition-width"
+                  class="${bgColoringClass} h-3 rounded-full pl-1 transition-all"
                   role="progressbar"
                   aria-valuenow="${mutationScoreRounded}"
                   aria-valuemin="0"
@@ -157,7 +157,7 @@ export class MutationTestReportTestMetricsTable<TFile, TMetric> extends Realtime
             : html` <span class="text-light-muted font-bold">N/A</span> `}
         </td>
         <td class="${textColoringClass} ${backgroundColoringClass} w-12 pr-2 text-center font-bold group-hover:bg-gray-200"
-          >${valueIsPresent ? mutationScoreRounded : nothing}</td
+          >${valueIsPresent ? html`<span class="transition-colors">${mutationScoreRounded}</span>` : nothing}</td
         >`;
     }
     return html`<td


### PR DESCRIPTION
Looks nice with the real-time updates 😃

<img width="346" alt="image" src="https://user-images.githubusercontent.com/10114577/237047383-5cf0940d-bc0a-4dc4-984f-89393c742f02.png">
