### PR TITLE
test(stryker): enable StrykerJS in `elements` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           node-version: 20.x
           cache: 'npm'
       - run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
       - run: npm run download-incremental-reports
       - name: Run Stryker incrementally
         run: |

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: 20.x
           cache: 'npm'
       - run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
       - name: Run Stryker
         run: npx nx run elements:stryker
         env:

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -34,7 +34,7 @@
     "test:integration:update": "playwright test --update-snapshots",
     "test:integration:headless": "cross-env HEADLESS=true playwright test",
     "postpublish": "PUBLISH_ELEMENTS=true ../metrics-scala/npmProjPublish.sh",
-    "stryker": "cross-env STRYKER=true echo 'FIXME: Stryker is not yet supported for this project'",
+    "stryker": "cross-env HEADLESS=true STRYKER=true stryker run",
     "lint": "eslint ."
   },
   "repository": {

--- a/packages/elements/stryker.conf.js
+++ b/packages/elements/stryker.conf.js
@@ -1,9 +1,14 @@
 import fs from 'fs/promises';
 
 /**
- * @type {Partial<import('@stryker-mutator/api/core').PartialStrykerOptions>}
+ * @type {import('@stryker-mutator/api/core').PartialStrykerOptions & typeof import('../../stryker.parent.json')}
  */
 const config = JSON.parse(await fs.readFile('../../stryker.parent.json', 'utf-8'));
+
+// @ts-expect-error removing gives error from parent.json type
+delete config.buildCommand;
+// @ts-expect-error removing gives error from parent.json type
+delete config.mochaOptions;
 
 config.dashboard = { module: 'elements' };
 config.testRunner = 'vitest';

--- a/packages/elements/vite.config.ts
+++ b/packages/elements/vite.config.ts
@@ -67,7 +67,7 @@ export default defineConfig(
           name: 'chromium',
           enabled: true,
           provider: 'playwright',
-          headless: !!(process.env.CI || process.env.HEADLESS),
+          headless: Boolean(process.env.CI || process.env.HEADLESS),
         },
       },
     }) satisfies UserConfig,

--- a/packages/metrics/stryker.conf.js
+++ b/packages/metrics/stryker.conf.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 
 /**
- * @type {Partial<import('@stryker-mutator/api/core').PartialStrykerOptions>}
+ * @type {import('@stryker-mutator/api/core').PartialStrykerOptions & typeof import('../../stryker.parent.json')}
  */
 const config = JSON.parse(await fs.readFile('../../stryker.parent.json', 'utf-8'));
 

--- a/packages/real-time/stryker.conf.js
+++ b/packages/real-time/stryker.conf.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 
 /**
- * @type {Partial<import('@stryker-mutator/api/core').PartialStrykerOptions>}
+ * @type {import('@stryker-mutator/api/core').PartialStrykerOptions & typeof import('../../stryker.parent.json')}
  */
 const config = JSON.parse(await fs.readFile('../../stryker.parent.json', 'utf-8'));
 

--- a/tasks/download-incremental-reports.sh
+++ b/tasks/download-incremental-reports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for package in elements metrics 
+for package in elements metrics real-time
 do
     if [ "$BRANCH_NAME" ]
     then


### PR DESCRIPTION
StrykerJS 8.0 supports vitest's browser mode 🎉

This PR re-enables StrykerJS on the `elements` package.