### PR TITLE
docs(supported mutators): fix Support table for Method Expression

### DIFF
--- a/docs/supported-mutators.md
+++ b/docs/supported-mutators.md
@@ -11,7 +11,7 @@ All Stryker versions support a variety of different mutators. We've aligned on a
 | ------------------------------------------------- | :----------------------------------------: | :----------------------------------------------: | :------------------------------------------: |
 | [Arithmetic Operator](#arithmetic-operator)       |                     ✅                     |                        ✅                        |                      ❌                      |
 | [Array Declaration](#array-declaration)           |                     ✅                     |                        ✅                        |                      ❌                      |
-| [Assignment Expression](#assignment-expression)   |                     ❌                     |                        ✅                        |                     n/a                      |
+| [Assignment Expression](#assignment-expression)   |                     ✅                     |                        ❌                        |                     n/a                      |
 | [Block Statement](#block-statement)               |                     ✅                     |                        ✅                        |                      ❌                      |
 | [Boolean Literal](#boolean-literal)               |                     ✅                     |                        ✅                        |                     ️✅                      |
 | [Checked Statement](#checked-statement)           |                    n/a                     |                        ✅                        |                     n/a                      |


### PR DESCRIPTION
Assignment Expression Only supported by Stryker-JS as mentioned here https://github.com/stryker-mutator/mutation-testing-elements/blob/ade7d944d663e079ce2b7e77aa20afbd7884e37c/docs/supported-mutators.md?plain=1#L65C6-L65C34