### PR TITLE
fix: flush real-time response after sending event

### DIFF
--- a/packages/real-time/package.json
+++ b/packages/real-time/package.json
@@ -17,6 +17,7 @@
     "middleware"
   ],
   "scripts": {
+    "test": "mocha --node-option enable-source-maps --forbid-only --forbid-pending dist/test/**/*.js",
     "lint": "eslint --ext .js,.ts .",
     "stryker": "stryker run"
   },

--- a/packages/real-time/src/mutation-event-sender.ts
+++ b/packages/real-time/src/mutation-event-sender.ts
@@ -35,5 +35,7 @@ export class MutationEventSender extends EventEmitter {
   #send<T>(event: string, payload: T): void {
     this.#response.write(`event: ${event}\n`);
     this.#response.write(`data: ${JSON.stringify(payload)}\n\n`);
+    // Flush the response buffer to ensure the client receives the event immediately
+    this.#response.flush?.();
   }
 }

--- a/packages/real-time/src/types.d.ts
+++ b/packages/real-time/src/types.d.ts
@@ -1,0 +1,10 @@
+declare module 'http' {
+  interface ServerResponse {
+    /**
+     * Forces the partially-compressed response to be flushed to the client.
+     *
+     * Only available when using compression.
+     */
+    flush?: () => void;
+  }
+}

--- a/packages/real-time/test/unit/mutation-event-sender.spec.ts
+++ b/packages/real-time/test/unit/mutation-event-sender.spec.ts
@@ -70,4 +70,15 @@ describe(MutationEventSender.name, () => {
     expect(responseMock.on.secondCall.args[0]).eq('error');
     sinon.assert.calledOnce(onCompleteStub);
   });
+
+  it('should call flush on each event, when available', () => {
+    const sut = new MutationEventSender(responseMock, onCompleteStub);
+    responseMock.flush = sinon.stub();
+
+    sut.sendMutantTested({ id: '1', status: 'Pending' });
+    sinon.assert.calledOnce(responseMock.flush);
+
+    sut.sendFinished();
+    sinon.assert.calledTwice(responseMock.flush);
+  });
 });


### PR DESCRIPTION
This fixes issues when using compression
