### PR TITLE
chore: disconnect from nx cloud

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,0 +1,36 @@
+name: 'Setup CI'
+description: 'Set up npm, Java, and cache for CI'
+inputs:
+  node-version:
+    description: 'The Node.js version to use'
+    default: '20.x'
+    required: false
+  setup-java:
+    description: 'Whether to set up Java'
+    default: 'false'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: nrwl/nx-set-shas@v4
+      with:
+        main-branch-name: master
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+    - uses: actions/setup-java@v4
+      if: ${{ inputs.setup-java == 'true' }}
+      with:
+        distribution: 'temurin'
+        java-version: 21
+        cache: 'sbt'
+    - uses: actions/cache@v4
+      with:
+        path: .nx
+        key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nx-
+    - run: npm ci
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
 
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-
 jobs:
   build_and_test:
     runs-on: ${{ matrix.os }}
@@ -22,20 +19,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: nrwl/nx-set-shas@v4
-        with:
-          main-branch-name: master
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/setup
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-          cache: 'sbt'
-      - run: npm ci
+          setup-java: true
       # Only install playwright if elements project is affected
       - name: affected
         id: affected
@@ -60,12 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: 'npm'
-      - run: npm ci
+      - uses: ./.github/setup
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
       - run: npm run download-incremental-reports

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: 'npm'
-      - run: npm ci
+      - uses: ./.github/setup
       - run: npx nx run metrics:stryker
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
@@ -26,11 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: 'npm'
-      - run: npm ci
+      - uses: ./.github/setup
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
       - name: Run Stryker
@@ -42,16 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/setup
         with:
-          node-version: 20.x
-          cache: 'npm'
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-          cache: 'sbt'
-      - run: npm ci
+          setup-java: true
       - name: Run Stryker
         run: npx nx run metrics-scala:stryker
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,20 +12,15 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: 21
-          cache: 'sbt'
-      - uses: actions/setup-node@v4
+          fetch-depth: 0
+      - uses: ./.github/setup
         with:
-          node-version: 20.x
-          cache: 'npm'
+          setup-java: true
       - name: Set Release Env
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           echo ${{ secrets.PGP_SECRET }} | base64 --decode | gpg --batch --import
-      - run: npm ci
       - run: npx nx run-many --target=build
       - name: Release
         run: npm run lerna:publish

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Generate token
@@ -19,12 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate-token.outputs.token }}
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - run: npm ci
+      - uses: ./.github/setup
       - run: npx playwright install chromium firefox --with-deps
       - run: npx nx run-many --target=build
       - run: npx nx run elements:test:integration:update

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
   "extends": "nx/presets/npm.json",
-  "nxCloudAccessToken": "ZWQ4NmEyMmYtYTcwZS00MmJlLTlmYzUtYTRjNWI1MmZiMDg1fHJlYWQ=",
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "{workspaceRoot}/package-lock.json", { "runtime": "node -v" }],
     "production": ["!{projectRoot}/test/**/*", "!{projectRoot}/.eslintrc", "!{projectRoot}/stryker.conf.js"]


### PR DESCRIPTION
Nx has recently introduced a new free plan that is about 1/3rd of the monthly credits. All it does is save the .nx/ cache folder, so we might as well just cache it on GitHub's cache and not be dependent on a third-party service.

Also sets up a composite action to set up the CI env