### PR TITLE
chore: add setup-sbt to GH actions

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -26,6 +26,7 @@ runs:
         distribution: 'temurin'
         java-version: 21
         cache: 'sbt'
+    - uses: sbt/setup-sbt@v1
     - uses: actions/cache@v4
       with:
         path: .nx/cache


### PR DESCRIPTION
Since the ubuntu-24 image, sbt is no longer included by default, so we have to install it
