### PR TITLE
chore: use html dialog element for file-picker

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.0",
   "description": "A suite of web components for a mutation testing report.",
   "unpkg": "dist/mutation-test-elements.js",
+  "browser": "dist/mutation-test-elements.js",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist-tsc/src/index.d.ts",

--- a/packages/elements/src/components/breadcrumb.ts
+++ b/packages/elements/src/components/breadcrumb.ts
@@ -78,6 +78,11 @@ export class MutationTestReportBreadcrumbComponent extends LitElement {
   }
 
   #dispatchFilePickerOpenEvent() {
+    // Move focus out of the button to the dialog
+    // In Chrome we need to call on `this`, on Firefox we need to call on the button
+    this.blur();
+    this.renderRoot.querySelector('button')?.blur();
+
     this.dispatchEvent(createCustomEvent('mte-file-picker-open', undefined));
   }
 }

--- a/packages/elements/test/integration/file-picker.it.spec.ts
+++ b/packages/elements/test/integration/file-picker.it.spec.ts
@@ -1,0 +1,24 @@
+import { ReportPage } from './po/ReportPage.js';
+import { test, expect } from '@playwright/test';
+
+test.describe('FilePicker', () => {
+  let page: ReportPage;
+
+  test.beforeEach(async ({ page: p }) => {
+    page = new ReportPage(p);
+    await page.navigateTo('test-files-example/#mutant/deep-merge.ts');
+  });
+
+  test('clicking search should open the file picker', async () => {
+    const filePicker = await page.breadcrumb().openFilePicker();
+    await expect(filePicker.picker()).toBeVisible();
+  });
+
+  test('pressing enter should open the file and close the file picker', async ({ page: p }) => {
+    const filePicker = await page.breadcrumb().openFilePicker();
+
+    await p.keyboard.press('Enter');
+    await page.mutantView.waitForVisible();
+    await expect(filePicker.picker()).not.toBeVisible();
+  });
+});

--- a/packages/elements/test/integration/po/FilePicker.po.ts
+++ b/packages/elements/test/integration/po/FilePicker.po.ts
@@ -8,4 +8,8 @@ export class FilePicker extends PageObject {
   public async results() {
     return this.$$('#files li');
   }
+
+  public picker() {
+    return this.$('dialog');
+  }
 }

--- a/packages/elements/test/unit/components/file-picker.component.spec.ts
+++ b/packages/elements/test/unit/components/file-picker.component.spec.ts
@@ -21,7 +21,7 @@ describe(MutationTestReportFilePickerComponent.name, () => {
     await sut.whenStable();
 
     // Assert
-    expect(getPicker()).not.toBeInTheDocument();
+    expect(getPicker()).not.toBeVisible();
   });
 
   it('should show the picker when keycombo is pressed', async () => {
@@ -85,7 +85,7 @@ describe(MutationTestReportFilePickerComponent.name, () => {
       await openPicker();
 
       // Assert
-      expect(getPicker()).not.toBeInTheDocument();
+      expect(getPicker()).not.toBeVisible();
     });
 
     it('should close the picker when the escape key is pressed', async () => {
@@ -94,17 +94,17 @@ describe(MutationTestReportFilePickerComponent.name, () => {
       await sut.whenStable();
 
       // Assert
-      expect(getPicker()).not.toBeInTheDocument();
+      expect(getPicker()).not.toBeVisible();
     });
 
     it('should close the picker when clicking outside the dialog', async () => {
       // Act
-      const backdrop = sut.$('#backdrop');
+      const backdrop = sut.$('dialog');
       backdrop.click();
       await sut.whenStable();
 
       // Assert
-      expect(getPicker()).not.toBeInTheDocument();
+      expect(getPicker()).not.toBeVisible();
     });
 
     describe('when not typing in the search box', () => {
@@ -226,7 +226,7 @@ describe(MutationTestReportFilePickerComponent.name, () => {
   }
 
   function getPicker() {
-    return sut.$('#picker');
+    return sut.$<HTMLDialogElement>('dialog');
   }
 
   function getActiveItem() {
@@ -234,6 +234,6 @@ describe(MutationTestReportFilePickerComponent.name, () => {
   }
 
   function getFilePickerInput() {
-    return sut.$<HTMLInputElement>('#file-picker-input');
+    return sut.$<HTMLInputElement>('input');
   }
 });


### PR DESCRIPTION
Also changes the logic slightly to depend on the dialog's `open` attribute. Because with that it becomes complex to track multiple open states (`openPicker` and `dialog.open`)