### PR TITLE
Python Code Highlighting support

### DIFF
--- a/packages/elements/src/lib/code-helpers.ts
+++ b/packages/elements/src/lib/code-helpers.ts
@@ -14,6 +14,7 @@ export enum ProgrammingLanguage {
   gherkin = 'gherkin',
   svelte = 'svelte',
   rust = 'rust',
+  python = 'python'
 }
 
 /**
@@ -59,6 +60,8 @@ export function determineLanguage(fileName: string): ProgrammingLanguage | undef
       return ProgrammingLanguage.svelte;
     case 'rs':
       return ProgrammingLanguage.rust;
+    case 'py':
+      return ProgrammingLanguage.python;
     default:
       return undefined;
   }

--- a/packages/elements/test/unit/lib/code-helpers.spec.ts
+++ b/packages/elements/test/unit/lib/code-helpers.spec.ts
@@ -18,6 +18,7 @@ describe(highlightCode.name, () => {
     ['foo.feature', ProgrammingLanguage.gherkin, 'Feature: foo'],
     ['foo.scala', ProgrammingLanguage.scala, 'object Foo { def main(args: Array[String]) = println("Hello, world!") }'],
     ['foo.rs', ProgrammingLanguage.rust, 'fn main() { println!("Hello, world!"); }'],
+    ['foo.py', ProgrammingLanguage.python, 'a = 10']
   ])(`should parse %s as %s`, (fileName, language, code) => {
     const highlightedCode = highlightCode(code, fileName);
     expect(highlightedCode).contains('<span'); // actual highlighting is not tested, in prism we trust
@@ -197,6 +198,7 @@ describe(determineLanguage.name, () => {
     ['php', ProgrammingLanguage.php],
     ['vue', ProgrammingLanguage.vue],
     ['feature', ProgrammingLanguage.gherkin],
+    ['py', ProgrammingLanguage.python]
   ] as const)(`should recognize file.%s as language %s`, (extension, expected) => {
     expect(determineLanguage(`file.${extension}`)).eq(expected);
   });


### PR DESCRIPTION
I am working on an adpater for python's mutation testing tools to `mutation-testing-elements` 

During that I realized that we do  not support python code highlighting