### PR TITLE
perf: multiple performance improvements to rendering and calculating scores

### DIFF
--- a/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
+++ b/packages/elements/src/components/drawer-mutant/drawer-mutant.component.ts
@@ -32,9 +32,12 @@ export class MutationTestReportDrawerMutant extends RealTimeElement {
   }
 
   public render() {
+    // Cache the computed test relations, `killedByTests`/`coveredByTests` resolve them on each call
+    const killedByTests = this.mutant?.killedByTests;
+    const coveredByTests = this.mutant?.coveredByTests;
     return renderDrawer(
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- we want to coalesce on length 0
-      { hasDetail: Boolean(this.mutant?.killedByTests?.length || this.mutant?.coveredByTests?.length || this.mutant?.statusReason), mode: this.mode },
+      { hasDetail: Boolean(killedByTests?.length || coveredByTests?.length || this.mutant?.statusReason), mode: this.mode },
       when(
         this.mutant,
         (mutant) =>
@@ -42,22 +45,22 @@ export class MutationTestReportDrawerMutant extends RealTimeElement {
               >${getEmojiForStatus(mutant.status)} ${mutant.mutatorName} ${mutant.status}
               (${mutant.location.start.line}:${mutant.location.start.column})</span
             >
-            <span slot="summary">${this.#renderSummary()}</span>
-            <span slot="detail" class="block">${this.#renderDetail()}</span>`,
+            <span slot="summary">${this.#renderSummary(killedByTests, coveredByTests)}</span>
+            <span slot="detail" class="block">${this.#renderDetail(killedByTests, coveredByTests)}</span>`,
       ),
     );
   }
 
-  #renderSummary() {
+  #renderSummary(killedByTests: TestModel[] | undefined, coveredByTests: TestModel[] | undefined) {
     return renderSummaryContainer(
-      html`${when(this.mutant?.killedByTests?.[0], (killedByTests) =>
+      html`${when(killedByTests?.[0], (firstKilledByTest) =>
         renderSummaryLine(
           html`${renderEmoji('🎯', 'killed')} Killed by:
-          ${killedByTests.name}${this.mutant!.killedByTests!.length > 1 ? `(and ${this.mutant!.killedByTests!.length - 1} more)` : ''}`,
+          ${firstKilledByTest.name}${killedByTests!.length > 1 ? `(and ${killedByTests!.length - 1} more)` : ''}`,
         ),
       )}
       ${when(this.mutant?.static, () => renderSummaryLine(html`${renderEmoji('🗿', 'static')} Static mutant`))}
-      ${when(this.mutant?.coveredByTests, (coveredTests) =>
+      ${when(coveredByTests, (coveredTests) =>
         renderSummaryLine(
           html`${renderEmoji('☂️', 'umbrella')} Covered by ${coveredTests.length}
           test${plural(coveredTests)}${this.mutant?.status === 'Survived' ? ' (yet still survived)' : ''}`,
@@ -70,13 +73,14 @@ export class MutationTestReportDrawerMutant extends RealTimeElement {
     );
   }
 
-  #renderDetail() {
+  #renderDetail(killedByTests: TestModel[] | undefined, coveredByTests: TestModel[] | undefined) {
+    const killedBySet = new Set(killedByTests);
     return html`<ul class="mr-2 mb-6">
-      ${map(this.mutant?.killedByTests, (test) =>
+      ${map(killedByTests, (test) =>
         renderDetailLine('This mutant was killed by this test', html`${renderEmoji('🎯', 'killed')} ${describeTest(test)}`),
       )}
       ${map(
-        this.mutant?.coveredByTests?.filter((test) => !this.mutant?.killedByTests?.includes(test)),
+        coveredByTests?.filter((test) => !killedBySet.has(test)),
         (test) => renderDetailLine('This mutant was covered by this test', html`${renderEmoji('☂️', 'umbrella')} ${describeTest(test)}`),
       )}
     </ul>`;

--- a/packages/elements/src/components/drawer-test/drawer-test.component.ts
+++ b/packages/elements/src/components/drawer-test/drawer-test.component.ts
@@ -27,9 +27,12 @@ export class MutationTestReportDrawerTestComponent extends RealTimeElement {
   }
 
   public render() {
+    // Cache the computed mutant relations, `killedMutants`/`coveredMutants` create new arrays on each call
+    const killedMutants = this.test?.killedMutants;
+    const coveredMutants = this.test?.coveredMutants;
     return renderDrawer(
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- we want to coalesce on length 0
-      { hasDetail: Boolean(this.test?.killedMutants?.length || this.test?.coveredMutants?.length), mode: this.mode },
+      { hasDetail: Boolean(killedMutants?.length || coveredMutants?.length), mode: this.mode },
       when(
         this.test,
         (test) =>
@@ -37,35 +40,36 @@ export class MutationTestReportDrawerTestComponent extends RealTimeElement {
               >${getEmojiForTestStatus(test.status)} ${test.name} [${test.status}]
               ${when(test.location, (location) => html`(${location.start.line}:${location.start.column})`)}</span
             >
-            <span slot="summary">${this.#renderSummary()}</span>
-            <span class="block" slot="detail">${this.#renderDetail()}</span>`,
+            <span slot="summary">${this.#renderSummary(killedMutants, coveredMutants)}</span>
+            <span class="block" slot="detail">${this.#renderDetail(killedMutants, coveredMutants)}</span>`,
       ),
     );
   }
 
-  #renderSummary() {
+  #renderSummary(killedMutants: MutantModel[] | undefined, coveredMutants: MutantModel[] | undefined) {
     return renderSummaryContainer(
-      html`${when(this.test?.killedMutants?.[0], (firstKilled) =>
+      html`${when(killedMutants?.[0], (firstKilled) =>
         renderSummaryLine(
           html`${renderEmoji('🎯', 'killed')} Killed:
-          ${describeMutant(firstKilled)}${this.test!.killedMutants!.length > 1 ? html` (and ${this.test!.killedMutants!.length - 1} more)` : ''}`,
+          ${describeMutant(firstKilled)}${killedMutants!.length > 1 ? html` (and ${killedMutants!.length - 1} more)` : ''}`,
         ),
       )}
-      ${when(this.test?.coveredMutants, (coveredMutants) =>
+      ${when(coveredMutants, (covered) =>
         renderSummaryLine(
-          html`${renderEmoji('☂️', 'umbrella')} Covered ${coveredMutants.length}
-          mutant${plural(coveredMutants)}${this.test?.status === TestStatus.Covering ? " (yet didn't kill any of them)" : ''}`,
+          html`${renderEmoji('☂️', 'umbrella')} Covered ${covered.length}
+          mutant${plural(covered)}${this.test?.status === TestStatus.Covering ? " (yet didn't kill any of them)" : ''}`,
         ),
       )}`,
     );
   }
-  #renderDetail() {
+  #renderDetail(killedMutants: MutantModel[] | undefined, coveredMutants: MutantModel[] | undefined) {
+    const killedSet = new Set(killedMutants);
     return html`<ul class="mr-2 mb-6">
-      ${map(this.test?.killedMutants, (mutant) =>
+      ${map(killedMutants, (mutant) =>
         renderDetailLine('This test killed this mutant', html`${renderEmoji('🎯', 'killed')} ${describeMutant(mutant)}`),
       )}
       ${map(
-        this.test?.coveredMutants?.filter((mutant) => !this.test?.killedMutants?.includes(mutant)),
+        coveredMutants?.filter((mutant) => !killedSet.has(mutant)),
         (mutant) => renderDetailLine('This test covered this mutant', html`${renderEmoji('☂️', 'umbrella')} ${describeMutant(mutant)}`),
       )}
     </ul>`;

--- a/packages/elements/src/components/file-picker/file-picker.component.ts
+++ b/packages/elements/src/components/file-picker/file-picker.component.ts
@@ -4,6 +4,7 @@ import type { PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { when } from 'lit/directives/when.js';
 import type { FileUnderTestModel, Metrics, MetricsResult, MutationTestMetricsResult, TestMetrics } from 'mutation-testing-metrics';
 import { TestFileModel } from 'mutation-testing-metrics';
 
@@ -16,6 +17,12 @@ interface ModelEntry {
   name: string;
   file: FileUnderTestModel | TestFileModel;
 }
+
+/**
+ * The maximum number of files to show in the picker.
+ * Rendering more list items makes opening/typing sluggish for large reports, narrowing the search is faster.
+ */
+const MAX_FILES_SHOWN = 150;
 
 @customElement('mte-file-picker')
 export class MutationTestReportFilePickerComponent extends BaseElement {
@@ -31,6 +38,9 @@ export class MutationTestReportFilePickerComponent extends BaseElement {
 
   @state()
   declare public fileIndex: number;
+
+  @state()
+  declare private moreFilesMessage: string | undefined;
 
   @query('dialog', true)
   declare private dialog: HTMLDialogElement;
@@ -145,6 +155,7 @@ export class MutationTestReportFilePickerComponent extends BaseElement {
               },
             )
       }
+      ${when(this.moreFilesMessage, (message) => html`<li class="p-2 text-sm text-gray-800" role="presentation">${message}</li>`)}
     </ul>`;
   }
 
@@ -273,9 +284,19 @@ export class MutationTestReportFilePickerComponent extends BaseElement {
 
   #filter(filterKey: string) {
     if (!filterKey) {
-      this.filteredFiles = this.#searchTargets;
+      if (this.#searchTargets.length > MAX_FILES_SHOWN) {
+        this.filteredFiles = this.#searchTargets.slice(0, MAX_FILES_SHOWN);
+        this.moreFilesMessage = `…and ${this.#searchTargets.length - MAX_FILES_SHOWN} more files — type to search`;
+      } else {
+        this.filteredFiles = this.#searchTargets;
+        this.moreFilesMessage = undefined;
+      }
     } else {
-      this.filteredFiles = goSearch(filterKey, this.#searchTargets, { key: 'prepared', threshold: 0.3, limit: 500 }).map((result) => ({
+      // Search for one more result than we show, to know whether the results were cut off
+      const results = goSearch(filterKey, this.#searchTargets, { key: 'prepared', threshold: 0.3, limit: MAX_FILES_SHOWN + 1 });
+
+      this.moreFilesMessage = results.length > MAX_FILES_SHOWN ? 'More matches available — refine your search' : undefined;
+      this.filteredFiles = results.slice(0, MAX_FILES_SHOWN).map((result) => ({
         file: result.obj.file,
         name: result.obj.name,
         template: result.highlight(

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -11,7 +11,7 @@
     "name": "metrics"
   },
   "scripts": {
-    "test": "mocha --node-option enable-source-maps --forbid-only --forbid-pending --retries 2 dist/test/**/*.js",
+    "test": "mocha --node-option enable-source-maps --forbid-only --forbid-pending --retries 2 \"dist/test/**/*.js\"",
     "stryker": "stryker run",
     "lint": "eslint ."
   },

--- a/packages/metrics/src/aggregate.ts
+++ b/packages/metrics/src/aggregate.ts
@@ -21,14 +21,27 @@ export function aggregateResultsByModule(resultsByModule: Record<string, Mutatio
   };
 
   return Object.entries(resultsByModule).reduce((acc, [moduleName, report]) => {
+    // Cache the unique ids per module. Test ids repeat in the `coveredBy`/`killedBy` lists of many mutants,
+    // reusing the same string instance saves a lot of memory on large reports.
+    const uniqueIds = new Map<string, string>();
+    const toUniqueId = (localId: string) => {
+      let uniqueId = uniqueIds.get(localId);
+      if (uniqueId === undefined) {
+        uniqueId = `${moduleName}_${localId}`;
+        uniqueIds.set(localId, uniqueId);
+      }
+      return uniqueId;
+    };
+    const toUniqueIds = (localIds: string[] | undefined) => localIds?.map(toUniqueId);
+
     Object.entries(normalizeFileNames(report.files)).forEach(([fileName, fileResult]) => {
       aggregatedResult.files[`${moduleName}/${fileName}`] = {
         ...fileResult,
         mutants: fileResult.mutants.map(({ id, coveredBy, killedBy, ...mutantData }) => ({
           ...mutantData,
-          id: toUniqueId(moduleName, id),
-          killedBy: toUniqueIds(moduleName, killedBy),
-          coveredBy: toUniqueIds(moduleName, coveredBy),
+          id: toUniqueId(id),
+          killedBy: toUniqueIds(killedBy),
+          coveredBy: toUniqueIds(coveredBy),
         })),
       };
     });
@@ -37,23 +50,11 @@ export function aggregateResultsByModule(resultsByModule: Record<string, Mutatio
       Object.entries(normalizeFileNames(report.testFiles)).forEach(([fileName, testFileResult]) => {
         aggregatedTestFiles[`${moduleName}/${fileName}`] = {
           ...testFileResult,
-          tests: testFileResult.tests.map(({ id, ...testData }) => ({ ...testData, id: toUniqueId(moduleName, id) })),
+          tests: testFileResult.tests.map(({ id, ...testData }) => ({ ...testData, id: toUniqueId(id) })),
         };
       });
     }
 
     return acc;
   }, aggregatedResult);
-}
-
-function toUniqueIds(moduleName: string, localIds: string[] | undefined): string[] | undefined {
-  if (localIds) {
-    const toUniqueIdForModule = toUniqueId.bind(undefined, moduleName);
-    return localIds.map(toUniqueIdForModule);
-  }
-  return;
-}
-
-function toUniqueId(moduleName: string, localId: string) {
-  return `${moduleName}_${localId}`;
 }

--- a/packages/metrics/src/calculateMetrics.ts
+++ b/packages/metrics/src/calculateMetrics.ts
@@ -109,20 +109,26 @@ function relate(mutants: MutantModel[], tests: TestModel[]) {
   const testMap = new Map<string, TestModel>(tests.map((test) => [test.id, test]));
 
   for (const mutant of mutants) {
-    const coveringTestIds = mutant.coveredBy ?? [];
-    for (const testId of coveringTestIds) {
-      const test = testMap.get(testId);
-      if (test) {
-        mutant.addCoveredBy(test);
-        test.addCovered(mutant);
+    mutant.relateTests(testMap);
+    const { coveredBy, killedBy } = mutant;
+    if (coveredBy) {
+      for (let i = 0; i < coveredBy.length; i++) {
+        const test = testMap.get(coveredBy[i]);
+        if (test) {
+          // Reuse the canonical test id string. JSON.parse allocates a new string for each
+          // occurrence, which wastes hundreds of MB on large reports.
+          coveredBy[i] = test.id;
+          test.addCoveredUnchecked(mutant);
+        }
       }
     }
-    const killingTestIds = mutant.killedBy ?? [];
-    for (const testId of killingTestIds) {
-      const test = testMap.get(testId);
-      if (test) {
-        mutant.addKilledBy(test);
-        test.addKilled(mutant);
+    if (killedBy) {
+      for (let i = 0; i < killedBy.length; i++) {
+        const test = testMap.get(killedBy[i]);
+        if (test) {
+          killedBy[i] = test.id;
+          test.addKilledUnchecked(mutant);
+        }
       }
     }
   }

--- a/packages/metrics/src/calculateMetrics.ts
+++ b/packages/metrics/src/calculateMetrics.ts
@@ -17,7 +17,7 @@ const ROOT_NAME_TESTS = 'All tests';
  */
 export function calculateMetrics(files: Record<string, FileResult>): MetricsResult<FileUnderTestModel, Metrics> {
   const normalizedFiles = normalize(files, '', (input, name) => new FileUnderTestModel(input, name));
-  return calculateDirectoryMetrics(ROOT_NAME, normalizedFiles, countFileMetrics);
+  return calculateDirectoryMetrics(ROOT_NAME, normalizedFiles, countFileMetrics, sumFileMetrics);
 }
 
 /**
@@ -35,12 +35,12 @@ export function calculateMutationTestMetrics(result: MutationTestResult): Mutati
       Object.values(testFileModels).flatMap((file) => file.tests),
     );
     return {
-      systemUnderTestMetrics: calculateRootMetrics(ROOT_NAME, fileModelsUnderTest, countFileMetrics),
-      testMetrics: calculateRootMetrics(ROOT_NAME_TESTS, testFileModels, countTestFileMetrics),
+      systemUnderTestMetrics: calculateRootMetrics(ROOT_NAME, fileModelsUnderTest, countFileMetrics, sumFileMetrics),
+      testMetrics: calculateRootMetrics(ROOT_NAME_TESTS, testFileModels, countTestFileMetrics, sumTestFileMetrics),
     };
   }
   return {
-    systemUnderTestMetrics: calculateRootMetrics(ROOT_NAME, fileModelsUnderTest, countFileMetrics),
+    systemUnderTestMetrics: calculateRootMetrics(ROOT_NAME, fileModelsUnderTest, countFileMetrics, sumFileMetrics),
     testMetrics: undefined,
   };
 }
@@ -49,6 +49,7 @@ function calculateRootMetrics<TFileModel, TMetrics>(
   name: string,
   files: Record<string, TFileModel>,
   calculateMetrics: (files: TFileModel[]) => TMetrics,
+  sumMetrics: (metrics: TMetrics[]) => TMetrics,
 ) {
   const fileNames = Object.keys(files);
   /**
@@ -58,7 +59,7 @@ function calculateRootMetrics<TFileModel, TMetrics>(
   if (fileNames.length === 1 && fileNames[0] === '') {
     return calculateFileMetrics(name, files[fileNames[0]], calculateMetrics);
   } else {
-    return calculateDirectoryMetrics(name, files, calculateMetrics);
+    return calculateDirectoryMetrics(name, files, calculateMetrics, sumMetrics);
   }
 }
 
@@ -66,9 +67,12 @@ function calculateDirectoryMetrics<TFileModel, TMetrics>(
   name: string,
   files: Record<string, TFileModel>,
   calculateMetrics: (files: TFileModel[]) => TMetrics,
+  sumMetrics: (metrics: TMetrics[]) => TMetrics,
 ): MetricsResult<TFileModel, TMetrics> {
-  const metrics = calculateMetrics(Object.values(files));
-  const childResults = toChildModels(files, calculateMetrics);
+  // Calculate the metrics of the children first, the metrics of a directory are the sum of its children.
+  // This makes the calculation O(files) instead of O(depth * files).
+  const childResults = toChildModels(files, calculateMetrics, sumMetrics);
+  const metrics = sumMetrics(childResults.map((childResult) => childResult.metrics));
   return new MetricsResult<TFileModel, TMetrics>(name, childResults, metrics);
 }
 
@@ -83,6 +87,7 @@ export function calculateFileMetrics<TFileModel, TMetrics>(
 function toChildModels<TFileModel, TMetrics>(
   files: Record<string, TFileModel>,
   calculateMetrics: (files: TFileModel[]) => TMetrics,
+  sumMetrics: (metrics: TMetrics[]) => TMetrics,
 ): MetricsResult<TFileModel, TMetrics>[] {
   const filesByDirectory = groupBy(Object.entries(files), (namedFile) => namedFile[0].split('/')[0]);
   return Object.keys(filesByDirectory)
@@ -95,7 +100,7 @@ function toChildModels<TFileModel, TMetrics>(
           },
           {} as Record<string, TFileModel>,
         );
-        return calculateDirectoryMetrics(directoryName, directoryFiles, calculateMetrics);
+        return calculateDirectoryMetrics(directoryName, directoryFiles, calculateMetrics, sumMetrics);
       } else {
         const [fileName, file] = filesByDirectory[directoryName][0];
         return calculateFileMetrics(fileName, file, calculateMetrics);
@@ -135,28 +140,97 @@ function relate(mutants: MutantModel[], tests: TestModel[]) {
 }
 
 export function countTestFileMetrics(testFile: TestFileModel[]): TestMetrics {
-  const tests = testFile.flatMap((_) => _.tests);
-  const count = (status: TestStatus) => tests.filter((_) => _.status === status).length;
+  const metrics: TestMetrics = { total: 0, killing: 0, covering: 0, notCovering: 0 };
+  for (const file of testFile) {
+    for (const test of file.tests) {
+      metrics.total++;
+      switch (test.status) {
+        case TestStatus.Killing:
+          metrics.killing++;
+          break;
+        case TestStatus.Covering:
+          metrics.covering++;
+          break;
+        case TestStatus.NotCovering:
+          metrics.notCovering++;
+          break;
+      }
+    }
+  }
+  return metrics;
+}
 
-  return {
-    total: tests.length,
-    killing: count(TestStatus.Killing),
-    covering: count(TestStatus.Covering),
-    notCovering: count(TestStatus.NotCovering),
-  };
+export function sumTestFileMetrics(metrics: TestMetrics[]): TestMetrics {
+  const result: TestMetrics = { total: 0, killing: 0, covering: 0, notCovering: 0 };
+  for (const metric of metrics) {
+    result.total += metric.total;
+    result.killing += metric.killing;
+    result.covering += metric.covering;
+    result.notCovering += metric.notCovering;
+  }
+  return result;
 }
 
 export function countFileMetrics(fileResult: FileUnderTestModel[]): Metrics {
-  const mutants = fileResult.flatMap((_) => _.mutants);
-  const count = (status: MutantStatus) => mutants.filter((_) => _.status === status).length;
-  const pending = count('Pending');
-  const killed = count('Killed');
-  const timeout = count('Timeout');
-  const survived = count('Survived');
-  const noCoverage = count('NoCoverage');
-  const runtimeErrors = count('RuntimeError');
-  const compileErrors = count('CompileError');
-  const ignored = count('Ignored');
+  const countByStatus: Record<MutantStatus, number> = {
+    Pending: 0,
+    Killed: 0,
+    Timeout: 0,
+    Survived: 0,
+    NoCoverage: 0,
+    RuntimeError: 0,
+    CompileError: 0,
+    Ignored: 0,
+  };
+  for (const file of fileResult) {
+    for (const mutant of file.mutants) {
+      countByStatus[mutant.status]++;
+    }
+  }
+  return toMetrics(
+    countByStatus.Pending,
+    countByStatus.Killed,
+    countByStatus.Timeout,
+    countByStatus.Survived,
+    countByStatus.NoCoverage,
+    countByStatus.RuntimeError,
+    countByStatus.CompileError,
+    countByStatus.Ignored,
+  );
+}
+
+export function sumFileMetrics(metrics: Metrics[]): Metrics {
+  let pending = 0,
+    killed = 0,
+    timeout = 0,
+    survived = 0,
+    noCoverage = 0,
+    runtimeErrors = 0,
+    compileErrors = 0,
+    ignored = 0;
+  for (const metric of metrics) {
+    pending += metric.pending;
+    killed += metric.killed;
+    timeout += metric.timeout;
+    survived += metric.survived;
+    noCoverage += metric.noCoverage;
+    runtimeErrors += metric.runtimeErrors;
+    compileErrors += metric.compileErrors;
+    ignored += metric.ignored;
+  }
+  return toMetrics(pending, killed, timeout, survived, noCoverage, runtimeErrors, compileErrors, ignored);
+}
+
+function toMetrics(
+  pending: number,
+  killed: number,
+  timeout: number,
+  survived: number,
+  noCoverage: number,
+  runtimeErrors: number,
+  compileErrors: number,
+  ignored: number,
+): Metrics {
   const totalDetected = timeout + killed;
   const totalUndetected = survived + noCoverage;
   const totalCovered = totalDetected + survived;

--- a/packages/metrics/src/model/metrics-result.ts
+++ b/packages/metrics/src/model/metrics-result.ts
@@ -1,7 +1,12 @@
-import { countFileMetrics, countTestFileMetrics } from '../calculateMetrics.js';
+import { countFileMetrics, countTestFileMetrics, sumFileMetrics, sumTestFileMetrics } from '../calculateMetrics.js';
 import type { FileUnderTestModel } from './file-under-test-model.js';
 import type { Metrics } from './metrics.js';
 import type { TestFileModel } from './test-file-model.js';
+import type { TestMetrics } from './test-metrics.js';
+
+function isTestMetrics(metrics: unknown): metrics is TestMetrics {
+  return typeof metrics === 'object' && metrics !== null && 'notCovering' in metrics;
+}
 
 /**
  * A metrics result of T for a directory or file
@@ -53,18 +58,20 @@ export class MetricsResult<TFile = FileUnderTestModel, TMetrics = Metrics> {
 
   public updateMetrics() {
     if (this.file === undefined) {
+      if (this.childResults.length === 0) {
+        return;
+      }
       this.childResults.forEach((childResult) => {
         childResult.updateMetrics();
       });
 
-      const files = this.#getFileModelsRecursively(this.childResults);
-      if (files.length === 0) {
-        return;
-      }
-      if ((files[0] as TestFileModel).tests) {
-        this.metrics = countTestFileMetrics(files as TestFileModel[]) as TMetrics;
+      // The metrics of a directory are the sum of the metrics of its children,
+      // no need to recount all descendant files at every level
+      const childMetrics = this.childResults.map((childResult) => childResult.metrics);
+      if (isTestMetrics(childMetrics[0])) {
+        this.metrics = sumTestFileMetrics(childMetrics as TestMetrics[]) as TMetrics;
       } else {
-        this.metrics = countFileMetrics(files as FileUnderTestModel[]) as TMetrics;
+        this.metrics = sumFileMetrics(childMetrics as Metrics[]) as TMetrics;
       }
 
       return;
@@ -75,22 +82,5 @@ export class MetricsResult<TFile = FileUnderTestModel, TMetrics = Metrics> {
     } else {
       this.metrics = countFileMetrics([this.file as FileUnderTestModel]) as TMetrics;
     }
-  }
-
-  #getFileModelsRecursively(childResults: MetricsResult<TFile, TMetrics>[]): TFile[] {
-    const flattenedFiles: TFile[] = [];
-    if (childResults.length === 0) {
-      return flattenedFiles;
-    }
-
-    childResults.forEach((child) => {
-      if (child.file) {
-        flattenedFiles.push(child.file);
-        return;
-      }
-      flattenedFiles.push(...this.#getFileModelsRecursively(child.childResults));
-    });
-
-    return flattenedFiles;
   }
 }

--- a/packages/metrics/src/model/mutant-model.ts
+++ b/packages/metrics/src/model/mutant-model.ts
@@ -30,26 +30,27 @@ export class MutantModel implements MutantResult {
 
   // New fields
   get coveredByTests(): TestModel[] | undefined {
-    if (this.#coveredByTests.size) {
-      return Array.from(this.#coveredByTests.values());
-    } else return undefined;
+    return this.#resolveTests(this.coveredBy);
   }
   set coveredByTests(tests: TestModel[]) {
-    this.#coveredByTests = new Map(tests.map((test) => [test.id, test]));
+    this.coveredBy = tests.map((test) => test.id);
+    tests.forEach((test) => this.#relateTest(test));
   }
 
   get killedByTests(): TestModel[] | undefined {
-    if (this.#killedByTests.size) {
-      return Array.from(this.#killedByTests.values());
-    } else return undefined;
+    return this.#resolveTests(this.killedBy);
   }
   set killedByTests(tests: TestModel[]) {
-    this.#killedByTests = new Map(tests.map((test) => [test.id, test]));
+    this.killedBy = tests.map((test) => test.id);
+    tests.forEach((test) => this.#relateTest(test));
   }
   declare public sourceFile: FileUnderTestModel | undefined;
 
-  #coveredByTests = new Map<string, TestModel>();
-  #killedByTests = new Map<string, TestModel>();
+  /**
+   * The tests of the report, keyed by id, used to resolve `coveredByTests`/`killedByTests` lazily.
+   * This map is shared with the other mutants in the report.
+   */
+  #relatedTests: Map<string, TestModel> | undefined;
 
   constructor(input: MutantResult) {
     this.coveredBy = input.coveredBy;
@@ -66,12 +67,53 @@ export class MutantModel implements MutantResult {
     this.testsCompleted = input.testsCompleted;
   }
 
+  /**
+   * Relates this mutant to the tests in the report (by id).
+   * @internal Called by `relate()` during `calculateMutationTestMetrics`. The tests are resolved
+   * lazily from `coveredBy`/`killedBy`, so the (potentially millions of) mutant-test relationships
+   * don't have to be stored in memory for large reports. The map is shared between all mutants of
+   * the report.
+   */
+  public relateTests(tests: Map<string, TestModel>) {
+    this.#relatedTests = tests;
+  }
+
   public addCoveredBy(test: TestModel) {
-    this.#coveredByTests.set(test.id, test);
+    this.#relateTest(test);
+    this.coveredBy ??= [];
+    if (!this.coveredBy.includes(test.id)) {
+      this.coveredBy.push(test.id);
+    }
   }
 
   public addKilledBy(test: TestModel) {
-    this.#killedByTests.set(test.id, test);
+    this.#relateTest(test);
+    this.killedBy ??= [];
+    if (!this.killedBy.includes(test.id)) {
+      this.killedBy.push(test.id);
+    }
+  }
+
+  #relateTest(test: TestModel) {
+    (this.#relatedTests ??= new Map()).set(test.id, test);
+  }
+
+  #resolveTests(ids: string[] | undefined): TestModel[] | undefined {
+    if (!ids?.length || !this.#relatedTests?.size) {
+      return undefined;
+    }
+    const tests: TestModel[] = [];
+    const seen = new Set<string>();
+    for (const id of ids) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        const test = this.#relatedTests.get(id);
+        if (test) {
+          tests.push(test);
+        }
+      }
+    }
+    return tests.length ? tests : undefined;
   }
 
   /**

--- a/packages/metrics/src/model/test-model.ts
+++ b/packages/metrics/src/model/test-model.ts
@@ -26,28 +26,53 @@ export class TestModel implements TestDefinition {
   public name!: string;
   public location?: OpenEndLocation | undefined;
 
-  get killedMutants() {
-    if (this.#killedMutants.size) {
-      return Array.from(this.#killedMutants.values());
+  get killedMutants(): MutantModel[] | undefined {
+    if (this.#killedMutants?.length) {
+      return [...this.#killedMutants];
     } else return undefined;
   }
 
-  get coveredMutants() {
-    if (this.#coveredMutants.size) {
-      return Array.from(this.#coveredMutants.values());
+  get coveredMutants(): MutantModel[] | undefined {
+    if (this.#coveredMutants?.length) {
+      return [...this.#coveredMutants];
     } else return undefined;
   }
   declare public sourceFile: TestFileModel | undefined;
 
-  #killedMutants = new Map<string, MutantModel>();
-  #coveredMutants = new Map<string, MutantModel>();
+  #killedMutants: MutantModel[] | undefined;
+  #coveredMutants: MutantModel[] | undefined;
 
   public addCovered(mutant: MutantModel) {
-    this.#coveredMutants.set(mutant.id, mutant);
+    this.#coveredMutants ??= [];
+    if (!this.#coveredMutants.some(({ id }) => id === mutant.id)) {
+      this.#coveredMutants.push(mutant);
+    }
+  }
+
+  /**
+   * Adds a covered mutant without checking whether it was already added.
+   * @internal Fast path for `relate()`, which skips the duplicate check: the relationships in a
+   * report are unique already, and checking for duplicates is too expensive when relating millions
+   * of mutant-test pairs. Use {@link addCovered} instead, which is safe to call more than once
+   * with the same mutant.
+   */
+  public addCoveredUnchecked(mutant: MutantModel) {
+    (this.#coveredMutants ??= []).push(mutant);
   }
 
   public addKilled(mutant: MutantModel) {
-    this.#killedMutants.set(mutant.id, mutant);
+    this.#killedMutants ??= [];
+    if (!this.#killedMutants.some(({ id }) => id === mutant.id)) {
+      this.#killedMutants.push(mutant);
+    }
+  }
+
+  /**
+   * Adds a killed mutant without checking whether it was already added.
+   * @internal Fast path for `relate()`, see {@link addCoveredUnchecked}.
+   */
+  public addKilledUnchecked(mutant: MutantModel) {
+    (this.#killedMutants ??= []).push(mutant);
   }
 
   constructor(input: TestDefinition) {
@@ -77,9 +102,9 @@ export class TestModel implements TestDefinition {
   }
 
   public get status(): TestStatus {
-    if (this.#killedMutants.size) {
+    if (this.#killedMutants?.length) {
       return TestStatus.Killing;
-    } else if (this.#coveredMutants.size) {
+    } else if (this.#coveredMutants?.length) {
       return TestStatus.Covering;
     } else {
       return TestStatus.NotCovering;


### PR DESCRIPTION
- **perf(metrics): resolve mutant-test relations lazily**
- **perf(metrics): sum directory metrics from children instead of recounting**
- **perf(metrics): intern unique ids when aggregating modules**
- **build: quote the mocha test glob**
- **perf(elements): avoid recomputing test/mutant relations per render**
- **perf(elements): cap the number of files rendered in the file picker**
